### PR TITLE
Get MeSH for multiple PMIDs

### DIFF
--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -36,6 +36,7 @@ __all__ = [
     "isa_or_partof",
     "get_pmids_for_mesh",
     "get_mesh_ids_for_pmid",
+    "get_mesh_ids_for_pmids",
     "get_evidences_for_mesh",
     "get_evidences_for_stmt_hash",
     "get_evidences_for_stmt_hashes",
@@ -709,6 +710,37 @@ def get_mesh_ids_for_pmid(
         source_type="Publication",
         target_type="BioEntity",
     )
+
+
+@autoclient()
+def get_mesh_ids_for_pmids(
+    pmids: List[str], *, client: Neo4jClient
+) -> Mapping[str, List[str]]:
+    """Return the MESH terms for the given PubMed ID.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    pmids :
+        The PubMed IDs to query.
+
+    Returns
+    -------
+    :
+        A dictionary from PubMed ID to MeSH IDs
+    """
+    pmid_terms = [("PUBMED", pubmed_id) for pubmed_id in pmids]
+    res = client.get_target_relations_for_sources(
+        sources=pmid_terms,
+        relation="annotated_with",
+        source_type="Publication",
+        target_type="BioEntity",
+    )
+    return {
+        pubmed: [r.target_id for r in relations]
+        for (_, pubmed), relations in res.items()
+    }
 
 
 @autoclient()

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -269,6 +269,17 @@ def test_get_mesh_ids_for_pmid():
 
 
 @pytest.mark.nonpublic
+def test_get_mesh_ids_for_pmids():
+    """Make a query over multiple pmids"""
+    client = _get_client()
+    pmids = ["27890007", "27890006"]
+    mesh_ids = get_mesh_ids_for_pmids(pmids, client=client)
+    assert isinstance(mesh_ids, dict)
+    assert all(pmid in mesh_ids for pmid in pmids)
+    assert "D000544" in mesh_ids["27890007"]
+
+
+@pytest.mark.nonpublic
 def test_get_evidence_obj_for_mesh_id():
     client = _get_client()
     mesh_id = ("MESH", "D015002")


### PR DESCRIPTION
This PR adds a new function (and related test) for getting MeSH identifiers for multiple articles by PMID.

Example:

```python
from indra_cogex.client.queries import get_mesh_ids_for_pmids

pmids = ["27890007", "27890006"]
mesh_ids = get_mesh_ids_for_pmids(pmids, client=client)
>>> mesh_ids
{
   "27890007": ["D000544", ...],
   "27890006": [ ... ]
}
```