### PR TITLE
Fixes related to #160, #161

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM labsyspharm/indra
 ARG INDRA_NEO4J_URL
 ARG INDRA_NEO4J_USER
 ARG INDRA_NEO4J_PASSWORD
+ARG INDRA_COGEX_WEB_LOCAL
 
 RUN pip3 install git+https://github.com/bgyori/indra_cogex.git#egg=indra_cogex[web,gunicorn,gsea] && \
     python -m indra.ontology.bio build && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,6 @@ FROM labsyspharm/indra
 ARG INDRA_NEO4J_URL
 ARG INDRA_NEO4J_USER
 ARG INDRA_NEO4J_PASSWORD
-ARG INDRA_COGEX_WEB_LOCAL
 
 RUN pip3 install git+https://github.com/bgyori/indra_cogex.git#egg=indra_cogex[web,gunicorn,gsea] && \
     python -m indra.ontology.bio build && \

--- a/src/indra_cogex/apps/curator/curator_blueprint.py
+++ b/src/indra_cogex/apps/curator/curator_blueprint.py
@@ -104,6 +104,7 @@ def _enrich_render_statements(
     title: str,
     description: str,
     curations: Optional[List[Mapping[str, Any]]] = None,
+    no_stmts_message: Optional[str] = None,
 ) -> Response:
     if curations is None:
         curations = curation_cache.get_curation_cache()
@@ -127,6 +128,7 @@ def _enrich_render_statements(
         evidence_lookup_time=evidence_lookup_time,
         curations=curations,
         description=description,
+        no_stmts_message=no_stmts_message
         # no limit necessary here since it was already applied above
     )
 
@@ -651,6 +653,7 @@ def subnetwork():
         <p>
         {nodes_html}
         """,
+        no_stmts_message="No statements found for the given nodes.",
     )
 
 

--- a/src/indra_cogex/apps/curator/curator_blueprint.py
+++ b/src/indra_cogex/apps/curator/curator_blueprint.py
@@ -35,6 +35,7 @@ from ..utils import (
     render_statements,
 )
 from ...client import get_stmts_for_paper, indra_subnetwork, indra_subnetwork_go
+from ...client.neo4j_client import process_identifier
 
 __all__ = [
     "curator_blueprint",
@@ -613,7 +614,7 @@ class NodesForm(FlaskForm):
         """Get the CURIEs from the form."""
         return sorted(
             {
-                tuple(entry.strip().split(":", 1))
+                tuple(process_identifier(entry.strip()))
                 for line in self.curies.data.split("\n")
                 for entry in line.strip().split(",")
             }

--- a/src/indra_cogex/apps/templates/data_display/data_display_base.html
+++ b/src/indra_cogex/apps/templates/data_display/data_display_base.html
@@ -76,7 +76,7 @@
                     </a>
                 {% else %}
                     <p class="card-text">
-                        There are no statements for this publication.
+                        {{ no_stmts_message if no_stmts_message else 'No statements to display.' }}
                     </p>
                 {% endif %}
             </div>

--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -17,7 +17,7 @@ from neo4j import GraphDatabase, Transaction, unit_of_work
 from indra_cogex.representation import Node, Relation, norm_id, \
     triple_query, triple_parameter_query
 
-__all__ = ["Neo4jClient", "autoclient"]
+__all__ = ["Neo4jClient", "autoclient", "process_identifier"]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR fixes some of the issues mentioned in #160:

- The option to pass a message when no statements are found is added as well as a more generic default message
- `process_identifier()` is done on the curies passed from the subnetwork form before passing them on to allow for some flexibility in how the curies are formatted
- `INDRA_COGEX_WEB_LOCAL` is passed as a build ARG in the Dockerfile to allow for downloads to be turned on

Curations are working again since #160 was posted.

Resolves #160.

Work on linking out to the statements when using INDRA up/downstream GSEA mentioned in #161 is ongoing work.