### PR TITLE
Add download to datatables

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ web =
 gunicorn =
     gunicorn
 gsea =
-    gseapy<0.12.0
+    gseapy
 docs =
     sphinx
     sphinx-rtd-theme

--- a/src/indra_cogex/apps/gla/gene_blueprint.py
+++ b/src/indra_cogex/apps/gla/gene_blueprint.py
@@ -8,7 +8,7 @@ import pandas as pd
 from flask import url_for
 from flask_wtf import FlaskForm
 from indra.databases import hgnc_client
-from wtforms import BooleanField, SubmitField, TextAreaField
+from wtforms import BooleanField, SubmitField, TextAreaField, StringField
 from wtforms.validators import DataRequired
 
 from indra_cogex.apps.constants import INDRA_COGEX_WEB_LOCAL
@@ -146,6 +146,18 @@ class ContinuousForm(FlaskForm):
     """A form for continuous gene set enrichment analysis."""
 
     file = file_field
+    gene_name_column = StringField(
+        "Gene Name Column",
+        description="The name of the column containing gene names (HGNC sybmols) in the "
+                    "uploaded file.",
+        validators=[DataRequired()],
+    )
+    log_fold_change_column = StringField(
+        "Log Fold Change Column",
+        description="The name of the column containing log fold change values in the "
+                    "uploaded file.",
+        validators=[DataRequired()],
+    )
     species = species_field
     permutations = permutations_field
     alpha = alpha_field
@@ -161,11 +173,23 @@ class ContinuousForm(FlaskForm):
         sep = "," if name.endswith("csv") else "\t"
         df = pd.read_csv(self.file.data, sep=sep)
         if self.species.data == "rat":
-            scores = get_rat_scores(df)
+            scores = get_rat_scores(
+                df,
+                gene_symbol_column_name=self.gene_name_column.data,
+                score_column_name=self.log_fold_change_column.data,
+            )
         elif self.species.data == "mouse":
-            scores = get_mouse_scores(df)
+            scores = get_mouse_scores(
+                df,
+                gene_symbol_column_name=self.gene_name_column.data,
+                score_column_name=self.log_fold_change_column.data,
+            )
         elif self.species.data == "human":
-            scores = get_human_scores(df)
+            scores = get_human_scores(
+                df,
+                gene_symbol_column_name=self.gene_name_column.data,
+                score_column_name=self.log_fold_change_column.data,
+            )
         else:
             raise ValueError(f"Unknown species: {self.species.data}")
         return scores

--- a/src/indra_cogex/apps/gla/gene_blueprint.py
+++ b/src/indra_cogex/apps/gla/gene_blueprint.py
@@ -167,7 +167,7 @@ class ContinuousForm(FlaskForm):
         elif self.species.data == "human":
             scores = get_human_scores(df)
         else:
-            raise ValueError
+            raise ValueError(f"Unknown species: {self.species.data}")
         return scores
 
 
@@ -387,7 +387,7 @@ def continuous_analysis():
                 minimum_belief=form.minimum_belief.data,
             )
         else:
-            raise ValueError
+            raise ValueError(f"Unknown source: {source}")
 
         return flask.render_template(
             "gene_analysis/continuous_results.html",

--- a/src/indra_cogex/apps/gla/gene_blueprint.py
+++ b/src/indra_cogex/apps/gla/gene_blueprint.py
@@ -324,6 +324,10 @@ def signed_analysis():
 def continuous_analysis():
     """Render the continuous analysis form."""
     form = ContinuousForm()
+    form.file.description = """\
+    Make sure the uploaded file contains at least two columns: one with gene names with
+    the column name "gene_name" (set in the first row) and one with the log fold change
+    values with the column name "log2FoldChange" (set in the first row)."""
     if form.validate_on_submit():
         scores = form.get_scores()
         source = form.source.data

--- a/src/indra_cogex/apps/templates/base.html
+++ b/src/indra_cogex/apps/templates/base.html
@@ -174,6 +174,40 @@
     <!-- Optional JavaScript -->
     {{ bootstrap.load_js() }}
     <script src="https://cdn.jsdelivr.net/gh/xcash/bootstrap-autocomplete@v2.3.7/dist/latest/bootstrap-autocomplete.min.js"></script>
+
+    <script>
+        {# See: https://stackoverflow.com/questions/15547198/export-html-table-to-csv-using-vanilla-javascript #}
+        // Quick and simple export target #table_id into a csv
+        function download_table_as_csv(table_id, separator = ',') {
+            // Select rows from table_id
+            var rows = document.querySelectorAll('table#' + table_id + ' tr');
+            // Construct csv
+            var csv = [];
+            for (var i = 0; i < rows.length; i++) {
+                var row = [], cols = rows[i].querySelectorAll('td, th');
+                for (var j = 0; j < cols.length; j++) {
+                    // Clean innertext to remove multiple spaces and jumpline (break csv)
+                    var data = cols[j].innerText.replace(/(\r\n|\n|\r)/gm, '').replace(/(\s\s)/gm, ' ')
+                    // Escape double-quote with double-double-quote (see https://stackoverflow.com/questions/17808511/properly-escape-a-double-quote-in-csv)
+                    data = data.replace(/"/g, '""');
+                    // Push escaped string
+                    row.push('"' + data + '"');
+                }
+                csv.push(row.join(separator));
+            }
+            var csv_string = csv.join('\n');
+            // Download it
+            var filename = 'export_' + table_id + '_' + new Date().toLocaleDateString() + '.csv';
+            var link = document.createElement('a');
+            link.style.display = 'none';
+            link.setAttribute('target', '_blank');
+            link.setAttribute('href', 'data:text/csv;charset=utf-8,' + encodeURIComponent(csv_string));
+            link.setAttribute('download', filename);
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        }
+    </script>
 {% endblock %}
 </body>
 </html>

--- a/src/indra_cogex/apps/templates/base.html
+++ b/src/indra_cogex/apps/templates/base.html
@@ -174,40 +174,6 @@
     <!-- Optional JavaScript -->
     {{ bootstrap.load_js() }}
     <script src="https://cdn.jsdelivr.net/gh/xcash/bootstrap-autocomplete@v2.3.7/dist/latest/bootstrap-autocomplete.min.js"></script>
-
-    <script>
-        {# See: https://stackoverflow.com/questions/15547198/export-html-table-to-csv-using-vanilla-javascript #}
-        // Quick and simple export target #table_id into a csv
-        function download_table_as_csv(table_id, separator = ',') {
-            // Select rows from table_id
-            var rows = document.querySelectorAll('table#' + table_id + ' tr');
-            // Construct csv
-            var csv = [];
-            for (var i = 0; i < rows.length; i++) {
-                var row = [], cols = rows[i].querySelectorAll('td, th');
-                for (var j = 0; j < cols.length; j++) {
-                    // Clean innertext to remove multiple spaces and jumpline (break csv)
-                    var data = cols[j].innerText.replace(/(\r\n|\n|\r)/gm, '').replace(/(\s\s)/gm, ' ')
-                    // Escape double-quote with double-double-quote (see https://stackoverflow.com/questions/17808511/properly-escape-a-double-quote-in-csv)
-                    data = data.replace(/"/g, '""');
-                    // Push escaped string
-                    row.push('"' + data + '"');
-                }
-                csv.push(row.join(separator));
-            }
-            var csv_string = csv.join('\n');
-            // Download it
-            var filename = 'export_' + table_id + '_' + new Date().toLocaleDateString() + '.csv';
-            var link = document.createElement('a');
-            link.style.display = 'none';
-            link.setAttribute('target', '_blank');
-            link.setAttribute('href', 'data:text/csv;charset=utf-8,' + encodeURIComponent(csv_string));
-            link.setAttribute('download', filename);
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
-        }
-    </script>
 {% endblock %}
 </body>
 </html>

--- a/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
@@ -20,12 +20,17 @@
             "order": [[2, "asc"]],
             pageLength: 10,
             layout: {
-                // Placement of paging needs to be specified or it won't show up
+                // Full documentation of layout:
+                // https://datatables.net/reference/option/layout
+                // The placement of paging needs to be specified or it won't
+                // show up at all
                 // See: https://datatables.net/reference/feature/pageLength
-                topStart: {
+                bottomStart: {
                     pageLength: {
                         menu: [10, 25, 50, 75, 100],
-                    },
+                    }
+                },
+                topStart: {
                     buttons: [
                         {
                             // CSV export, see: https://datatables.net/reference/button/csv#Examples

--- a/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
@@ -18,11 +18,17 @@
     <script>
         const datatablesConf = {
             "order": [[2, "asc"]],
-            // CSV export, see: https://datatables.net/reference/button/csv#Examples
+            pageLength: 10,
             layout: {
+                // Placement of paging needs to be specified or it won't show up
+                // See: https://datatables.net/reference/feature/pageLength
                 topStart: {
+                    pageLength: {
+                        menu: [10, 25, 50, 75, 100],
+                    },
                     buttons: [
                         {
+                            // CSV export, see: https://datatables.net/reference/button/csv#Examples
                             extend: 'csv',
                             text: 'Download full table as CSV',
                             exportOptions: {

--- a/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
@@ -6,16 +6,15 @@
     {{ super() }}
     <!-- DataTables, see: https://datatables.net/examples/styling/bootstrap4.html-->
     <link
+            href="https://cdn.datatables.net/v/bs4/jszip-3.10.1/dt-2.0.7/b-3.0.2/b-html5-3.0.2/datatables.min.css"
             rel="stylesheet"
-            href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap4.min.css"
     />
 {% endblock %}
 
 {% block scripts %}
     {{ super() }}
     <!-- DataTables, see: https://datatables.net/examples/styling/bootstrap4.html-->
-    <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
-    <script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap4.min.js"></script>
+    <script src="https://cdn.datatables.net/v/bs4/jszip-3.10.1/dt-2.0.7/b-3.0.2/b-html5-3.0.2/datatables.min.js"></script>
     <script>
         const datatablesConf = {
             "order": [[2, "asc"]],
@@ -92,14 +91,6 @@
                     {% elif source == "indra-downstream" %}
                         INDRA downstream regulators.
                     {% endif %}
-                </p>
-                {# Download button #}
-                <p>
-                    <button
-                        class="btn btn-primary"
-                        onclick="download_table_as_csv('table-continuous');">
-                        Download <i class="fas fa-download"></i>
-                    </button>
                 </p>
                 {{ render_table(results, "table-continuous") }}
             </div>

--- a/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
@@ -75,6 +75,14 @@
                         INDRA downstream regulators.
                     {% endif %}
                 </p>
+                {# Download button #}
+                <p>
+                    <button
+                        class="btn btn-primary"
+                        onclick="download_table_as_csv('table-continuous');">
+                        Download <i class="fas fa-download"></i>
+                    </button>
+                </p>
                 {{ render_table(results, "table-continuous") }}
             </div>
         </div>

--- a/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
@@ -48,7 +48,7 @@
 {% endblock %}
 
 {% macro render_table(df, table_id) -%}
-    <table class="table table-hover table-striped" id="{{ table_id }}">
+    <table class="table table-hover table-striped" id="{{ table_id }}" style="width: 100%;">
         <thead>
         <tr>
             <th scope="col">CURIE</th>

--- a/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
@@ -17,7 +17,25 @@
     <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
     <script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap4.min.js"></script>
     <script>
-        const datatablesConf = {"order": [[2, "asc"]]};
+        const datatablesConf = {
+            "order": [[2, "asc"]],
+            // CSV export, see: https://datatables.net/reference/button/csv#Examples
+            layout: {
+                topStart: {
+                    buttons: [
+                        {
+                            extend: 'csv',
+                            text: 'Copy all data',
+                            exportOptions: {
+                                modifier: {
+                                    search: 'none'
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        };
         $(document).ready(function () {
             $("#table-continuous").DataTable(datatablesConf);
         });

--- a/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/continuous_results.html
@@ -24,7 +24,7 @@
                     buttons: [
                         {
                             extend: 'csv',
-                            text: 'Copy all data',
+                            text: 'Download full table as CSV',
                             exportOptions: {
                                 modifier: {
                                     search: 'none'

--- a/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
@@ -55,7 +55,7 @@
 {% endblock %}
 
 {% macro render_table(df, table_id) -%}
-    <table class="table table-hover table-striped table-ora" id="{{ table_id }}">
+    <table class="table table-hover table-striped table-ora" id="{{ table_id }}" style="width: 100%;">
         <thead>
         <tr>
             <th scope="col">CURIE</th>

--- a/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
@@ -20,12 +20,17 @@
             "order": [[2, "asc"]],
             pageLength: 10,
             layout: {
-                // Placement of paging needs to be specified or it won't show up
+                // Full documentation of layout:
+                // https://datatables.net/reference/option/layout
+                // The placement of paging needs to be specified or it won't
+                // show up at all
                 // See: https://datatables.net/reference/feature/pageLength
-                topStart: {
+                bottomStart: {
                     pageLength: {
                         menu: [10, 25, 50, 75, 100],
-                    },
+                    }
+                },
+                topStart: {
                     buttons: [
                         {
                             // CSV export, see: https://datatables.net/reference/button/csv#Examples

--- a/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
@@ -18,11 +18,17 @@
     <script>
         const datatablesConf = {
             "order": [[2, "asc"]],
-            // CSV export, see: https://datatables.net/reference/button/csv#Examples
+            pageLength: 10,
             layout: {
+                // Placement of paging needs to be specified or it won't show up
+                // See: https://datatables.net/reference/feature/pageLength
                 topStart: {
+                    pageLength: {
+                        menu: [10, 25, 50, 75, 100],
+                    },
                     buttons: [
                         {
+                            // CSV export, see: https://datatables.net/reference/button/csv#Examples
                             extend: 'csv',
                             text: 'Download full table as CSV',
                             exportOptions: {

--- a/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
@@ -6,16 +6,15 @@
     {{ super() }}
     <!-- DataTables, see: https://datatables.net/examples/styling/bootstrap4.html-->
     <link
+            href="https://cdn.datatables.net/v/bs4/jszip-3.10.1/dt-2.0.7/b-3.0.2/b-html5-3.0.2/datatables.min.css"
             rel="stylesheet"
-            href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap4.min.css"
     />
 {% endblock %}
 
 {% block scripts %}
     {{ super() }}
     <!-- DataTables, see: https://datatables.net/examples/styling/bootstrap4.html-->
-    <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
-    <script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap4.min.js"></script>
+    <script src="https://cdn.datatables.net/v/bs4/jszip-3.10.1/dt-2.0.7/b-3.0.2/b-html5-3.0.2/datatables.min.js"></script>
     <script>
         const datatablesConf = {
             "order": [[2, "asc"]],

--- a/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
@@ -24,7 +24,7 @@
                     buttons: [
                         {
                             extend: 'csv',
-                            text: 'Copy all data',
+                            text: 'Download full table as CSV',
                             exportOptions: {
                                 modifier: {
                                     search: 'none'

--- a/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
@@ -17,7 +17,25 @@
     <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
     <script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap4.min.js"></script>
     <script>
-        const datatablesConf = {"order": [[2, "asc"]]};
+        const datatablesConf = {
+            "order": [[2, "asc"]],
+            // CSV export, see: https://datatables.net/reference/button/csv#Examples
+            layout: {
+                topStart: {
+                    buttons: [
+                        {
+                            extend: 'csv',
+                            text: 'Copy all data',
+                            exportOptions: {
+                                modifier: {
+                                    search: 'none'
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        };
         $(document).ready(function () {
             $("#table-go").DataTable(datatablesConf);
             $("#table-reactome").DataTable(datatablesConf);
@@ -127,14 +145,6 @@
                             via the <a href="http://geneontology.org/docs/go-annotations/">Gene
                             Ontology Annotations Database</a>.
                         </p>
-                        <p>
-                            {# Download button #}
-                            <button
-                                class="btn btn-primary"
-                                onclick="download_table_as_csv('table-go');">
-                                Download <i class="fas fa-download"></i>
-                            </button>
-                        </p>
                         {{ render_table(go_results, "table-go") }}
                     </div>
                     <div class="tab-pane" id="reactome" role="tabpanel" aria-labelledby="reactome-tab">
@@ -143,14 +153,6 @@
                             and correcting using {{ method }} and α={{ alpha }} on the genes annotated to pathways in
                             the <a href="https://reactome.org/">Reactome</a>
                             pathway database.
-                        </p>
-                        <p>
-                            {# Download button #}
-                            <button
-                                class="btn btn-primary"
-                                onclick="download_table_as_csv('table-reactome');">
-                                Download <i class="fas fa-download"></i>
-                            </button>
                         </p>
                         {{ render_table(reactome_results, "table-reactome") }}
                     </div>
@@ -161,14 +163,6 @@
                             the <a href="https://www.wikipathways.org/">WikiPathways</a>
                             pathway database.
                         </p>
-                        <p>
-                            {# Download button #}
-                            <button
-                                class="btn btn-primary"
-                                onclick="download_table_as_csv('table-wikipathways');">
-                                Download <i class="fas fa-download"></i>
-                            </button>
-                        </p>
                         {{ render_table(wikipathways_results, "table-wikipathways") }}
                     </div>
                     <div class="tab-pane" id="hpo" role="tabpanel" aria-labelledby="hpo-tab">
@@ -176,14 +170,6 @@
                             These results are acquired by running over-representation analysis using Fisher's exact test
                             and correcting using {{ method }} and α={{ alpha }} on the genes annotated to phenotypes in
                             the <a href="https://hpo.jax.org/">Human Phenotype Ontology annotation database</a>.
-                        </p>
-                        <p>
-                            {# Download button #}
-                            <button
-                                class="btn btn-primary"
-                                onclick="download_table_as_csv('table-hpo');">
-                                Download <i class="fas fa-download"></i>
-                            </button>
                         </p>
                         {{ render_table(phenotype_results, "table-hpo") }}
                     </div>
@@ -198,12 +184,6 @@
                                 one step from all entities in the INDRA Database.
                             </p>
                             <p>
-                                {# Download button #}
-                                <button
-                                    class="btn btn-primary"
-                                    onclick="download_table_as_csv('table-downstream');">
-                                    Download <i class="fas fa-download"></i>
-                                </button>
                             </p>
                             {{ render_table(indra_downstream_results, "table-downstream") }}
                         </div>
@@ -215,14 +195,6 @@
                                 These results are acquired by running over-representation analysis using Fisher's exact test
                                 and correcting using {{ method }} and α={{ alpha }} on genes causally upstream in
                                 one step from all entities in the INDRA Database.
-                            </p>
-                            <p>
-                                {# Download button #}
-                                <button
-                                    class="btn btn-primary"
-                                    onclick="download_table_as_csv('table-upstream');">
-                                    Download <i class="fas fa-download"></i>
-                                </button>
                             </p>
                             {{ render_table(indra_upstream_results, "table-upstream") }}
                         </div>

--- a/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/discrete_results.html
@@ -127,6 +127,14 @@
                             via the <a href="http://geneontology.org/docs/go-annotations/">Gene
                             Ontology Annotations Database</a>.
                         </p>
+                        <p>
+                            {# Download button #}
+                            <button
+                                class="btn btn-primary"
+                                onclick="download_table_as_csv('table-go');">
+                                Download <i class="fas fa-download"></i>
+                            </button>
+                        </p>
                         {{ render_table(go_results, "table-go") }}
                     </div>
                     <div class="tab-pane" id="reactome" role="tabpanel" aria-labelledby="reactome-tab">
@@ -135,6 +143,14 @@
                             and correcting using {{ method }} and α={{ alpha }} on the genes annotated to pathways in
                             the <a href="https://reactome.org/">Reactome</a>
                             pathway database.
+                        </p>
+                        <p>
+                            {# Download button #}
+                            <button
+                                class="btn btn-primary"
+                                onclick="download_table_as_csv('table-reactome');">
+                                Download <i class="fas fa-download"></i>
+                            </button>
                         </p>
                         {{ render_table(reactome_results, "table-reactome") }}
                     </div>
@@ -145,6 +161,14 @@
                             the <a href="https://www.wikipathways.org/">WikiPathways</a>
                             pathway database.
                         </p>
+                        <p>
+                            {# Download button #}
+                            <button
+                                class="btn btn-primary"
+                                onclick="download_table_as_csv('table-wikipathways');">
+                                Download <i class="fas fa-download"></i>
+                            </button>
+                        </p>
                         {{ render_table(wikipathways_results, "table-wikipathways") }}
                     </div>
                     <div class="tab-pane" id="hpo" role="tabpanel" aria-labelledby="hpo-tab">
@@ -152,6 +176,14 @@
                             These results are acquired by running over-representation analysis using Fisher's exact test
                             and correcting using {{ method }} and α={{ alpha }} on the genes annotated to phenotypes in
                             the <a href="https://hpo.jax.org/">Human Phenotype Ontology annotation database</a>.
+                        </p>
+                        <p>
+                            {# Download button #}
+                            <button
+                                class="btn btn-primary"
+                                onclick="download_table_as_csv('table-hpo');">
+                                Download <i class="fas fa-download"></i>
+                            </button>
                         </p>
                         {{ render_table(phenotype_results, "table-hpo") }}
                     </div>
@@ -165,6 +197,14 @@
                                 and correcting using {{ method }} and α={{ alpha }} on genes causally downstream in
                                 one step from all entities in the INDRA Database.
                             </p>
+                            <p>
+                                {# Download button #}
+                                <button
+                                    class="btn btn-primary"
+                                    onclick="download_table_as_csv('table-downstream');">
+                                    Download <i class="fas fa-download"></i>
+                                </button>
+                            </p>
                             {{ render_table(indra_downstream_results, "table-downstream") }}
                         </div>
                         <div class="tab-pane" id="upstream" role="tabpanel" aria-labelledby="upstream-tab">
@@ -175,6 +215,14 @@
                                 These results are acquired by running over-representation analysis using Fisher's exact test
                                 and correcting using {{ method }} and α={{ alpha }} on genes causally upstream in
                                 one step from all entities in the INDRA Database.
+                            </p>
+                            <p>
+                                {# Download button #}
+                                <button
+                                    class="btn btn-primary"
+                                    onclick="download_table_as_csv('table-upstream');">
+                                    Download <i class="fas fa-download"></i>
+                                </button>
                             </p>
                             {{ render_table(indra_upstream_results, "table-upstream") }}
                         </div>

--- a/src/indra_cogex/apps/templates/gene_analysis/signed_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/signed_results.html
@@ -95,6 +95,14 @@
                     query gene set. A <i>p</i>-value is calculated by applying a binomial test to the matches and
                     non-matches.
                 </p>
+                {# Download button #}
+                <p>
+                    <button
+                        class="btn btn-primary"
+                        onclick="download_table_as_csv('table-rcr');">
+                        Download <i class="fas fa-download"></i>
+                    </button>
+                </p>
                 {{ render_table(results, "table-rcr") }}
             </div>
         </div>

--- a/src/indra_cogex/apps/templates/gene_analysis/signed_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/signed_results.html
@@ -6,16 +6,15 @@
     {{ super() }}
     <!-- DataTables, see: https://datatables.net/examples/styling/bootstrap4.html-->
     <link
+            href="https://cdn.datatables.net/v/bs4/jszip-3.10.1/dt-2.0.7/b-3.0.2/b-html5-3.0.2/datatables.min.css"
             rel="stylesheet"
-            href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap4.min.css"
     />
 {% endblock %}
 
 {% block scripts %}
     {{ super() }}
     <!-- DataTables, see: https://datatables.net/examples/styling/bootstrap4.html-->
-    <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
-    <script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap4.min.js"></script>
+    <script src="https://cdn.datatables.net/v/bs4/jszip-3.10.1/dt-2.0.7/b-3.0.2/b-html5-3.0.2/datatables.min.js"></script>
     <script>
         const datatablesConf = {
             "order": [[2, "asc"]],
@@ -112,14 +111,6 @@
                     inhibited/down-regulated genes for each entity in the INDRA database with a positive and negative
                     query gene set. A <i>p</i>-value is calculated by applying a binomial test to the matches and
                     non-matches.
-                </p>
-                {# Download button #}
-                <p>
-                    <button
-                        class="btn btn-primary"
-                        onclick="download_table_as_csv('table-rcr');">
-                        Download <i class="fas fa-download"></i>
-                    </button>
                 </p>
                 {{ render_table(results, "table-rcr") }}
             </div>

--- a/src/indra_cogex/apps/templates/gene_analysis/signed_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/signed_results.html
@@ -17,7 +17,25 @@
     <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
     <script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap4.min.js"></script>
     <script>
-        const datatablesConf = {"order": [[2, "asc"]]};
+        const datatablesConf = {
+            "order": [[2, "asc"]],
+            // CSV export, see: https://datatables.net/reference/button/csv#Examples
+            layout: {
+                topStart: {
+                    buttons: [
+                        {
+                            extend: 'csv',
+                            text: 'Copy all data',
+                            exportOptions: {
+                                modifier: {
+                                    search: 'none'
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        };
         $(document).ready(function () {
             $("#table-rcr").DataTable(datatablesConf);
         });

--- a/src/indra_cogex/apps/templates/gene_analysis/signed_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/signed_results.html
@@ -20,12 +20,17 @@
             "order": [[2, "asc"]],
             pageLength: 10,
             layout: {
-                // Placement of paging needs to be specified or it won't show up
+                // Full documentation of layout:
+                // https://datatables.net/reference/option/layout
+                // The placement of paging needs to be specified or it won't
+                // show up at all
                 // See: https://datatables.net/reference/feature/pageLength
-                topStart: {
+                bottomStart: {
                     pageLength: {
                         menu: [10, 25, 50, 75, 100],
-                    },
+                    }
+                },
+                topStart: {
                     buttons: [
                         {
                             // CSV export, see: https://datatables.net/reference/button/csv#Examples

--- a/src/indra_cogex/apps/templates/gene_analysis/signed_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/signed_results.html
@@ -18,11 +18,17 @@
     <script>
         const datatablesConf = {
             "order": [[2, "asc"]],
-            // CSV export, see: https://datatables.net/reference/button/csv#Examples
+            pageLength: 10,
             layout: {
+                // Placement of paging needs to be specified or it won't show up
+                // See: https://datatables.net/reference/feature/pageLength
                 topStart: {
+                    pageLength: {
+                        menu: [10, 25, 50, 75, 100],
+                    },
                     buttons: [
                         {
+                            // CSV export, see: https://datatables.net/reference/button/csv#Examples
                             extend: 'csv',
                             text: 'Download full table as CSV',
                             exportOptions: {

--- a/src/indra_cogex/apps/templates/gene_analysis/signed_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/signed_results.html
@@ -48,7 +48,7 @@
 {% endblock %}
 
 {% macro render_table(df, table_id) -%}
-    <table class="table table-hover table-striped" id="{{ table_id }}">
+    <table class="table table-hover table-striped" id="{{ table_id }}" style="width: 100%;">
         <thead>
         <tr>
             <th scope="col">CURIE</th>

--- a/src/indra_cogex/apps/templates/gene_analysis/signed_results.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/signed_results.html
@@ -24,7 +24,7 @@
                     buttons: [
                         {
                             extend: 'csv',
-                            text: 'Copy all data',
+                            text: 'Download full table as CSV',
                             exportOptions: {
                                 modifier: {
                                     search: 'none'

--- a/src/indra_cogex/apps/templates/metabolite_analysis/discrete_results.html
+++ b/src/indra_cogex/apps/templates/metabolite_analysis/discrete_results.html
@@ -20,12 +20,17 @@
             "order": [[2, "asc"]],
             pageLength: 10,
             layout: {
-                // Placement of paging needs to be specified or it won't show up
+                // Full documentation of layout:
+                // https://datatables.net/reference/option/layout
+                // The placement of paging needs to be specified or it won't
+                // show up at all
                 // See: https://datatables.net/reference/feature/pageLength
-                topStart: {
+                bottomStart: {
                     pageLength: {
                         menu: [10, 25, 50, 75, 100],
-                    },
+                    }
+                },
+                topStart: {
                     buttons: [
                         {
                             // CSV export, see: https://datatables.net/reference/button/csv#Examples

--- a/src/indra_cogex/apps/templates/metabolite_analysis/discrete_results.html
+++ b/src/indra_cogex/apps/templates/metabolite_analysis/discrete_results.html
@@ -6,18 +6,41 @@
     {{ super() }}
     <!-- DataTables, see: https://datatables.net/examples/styling/bootstrap4.html-->
     <link
+            href="https://cdn.datatables.net/v/bs4/jszip-3.10.1/dt-2.0.7/b-3.0.2/b-html5-3.0.2/datatables.min.css"
             rel="stylesheet"
-            href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap4.min.css"
     />
 {% endblock %}
 
 {% block scripts %}
     {{ super() }}
     <!-- DataTables, see: https://datatables.net/examples/styling/bootstrap4.html-->
-    <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
-    <script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap4.min.js"></script>
+    <script src="https://cdn.datatables.net/v/bs4/jszip-3.10.1/dt-2.0.7/b-3.0.2/b-html5-3.0.2/datatables.min.js"></script>
     <script>
-        const datatablesConf = {"order": [[2, "asc"]]};
+        const datatablesConf = {
+            "order": [[2, "asc"]],
+            pageLength: 10,
+            layout: {
+                // Placement of paging needs to be specified or it won't show up
+                // See: https://datatables.net/reference/feature/pageLength
+                topStart: {
+                    pageLength: {
+                        menu: [10, 25, 50, 75, 100],
+                    },
+                    buttons: [
+                        {
+                            // CSV export, see: https://datatables.net/reference/button/csv#Examples
+                            extend: 'csv',
+                            text: 'Download full table as CSV',
+                            exportOptions: {
+                                modifier: {
+                                    search: 'none'
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        };
         $(document).ready(function () {
             $("#table-results").DataTable(datatablesConf);
         });

--- a/src/indra_cogex/apps/templates/metabolite_analysis/discrete_results.html
+++ b/src/indra_cogex/apps/templates/metabolite_analysis/discrete_results.html
@@ -48,7 +48,7 @@
 {% endblock %}
 
 {% macro render_table(df, table_id) -%}
-    <table class="table table-hover table-striped table-ora" id="{{ table_id }}">
+    <table class="table table-hover table-striped table-ora" id="{{ table_id }}" style="width: 100%;">
         <thead>
         <tr>
             <th scope="col">EC Code</th>

--- a/src/indra_cogex/client/enrichment/continuous.py
+++ b/src/indra_cogex/client/enrichment/continuous.py
@@ -42,33 +42,12 @@ __all__ = [
     "gsea",
 ]
 
-GENE_SYMBOL_COLUMN_GUESSES = [
-    "gene_name",
-]
-SCORE_COLUMN_GUESSES = [
-    "log2FoldChange",
-]
-
-
-def _guess_symbol_col(df: pd.DataFrame) -> str:
-    for guess in GENE_SYMBOL_COLUMN_GUESSES:
-        if guess in df.columns:
-            return guess
-    raise ValueError(f"could not guess gene symbol column name from: {df.columns}")
-
-
-def _guess_score_col(df: pd.DataFrame) -> str:
-    for guess in SCORE_COLUMN_GUESSES:
-        if guess in df.columns:
-            return guess
-    raise ValueError(f"could not guess score column name from: {df.columns}")
-
 
 def get_rat_scores(
     path: Union[Path, str, pd.DataFrame],
+    gene_symbol_column_name: str,
+    score_column_name: str,
     read_csv_kwargs: Optional[Dict[str, Any]] = None,
-    gene_symbol_column_name: Optional[str] = None,
-    score_column_name: Optional[str] = None,
 ) -> Dict[str, float]:
     """Load a differential gene expression file with rat measurements.
 
@@ -107,9 +86,9 @@ def get_rat_scores(
 
 def get_mouse_scores(
     path: Union[Path, str, pd.DataFrame],
+    gene_symbol_column_name: str,
+    score_column_name: str,
     read_csv_kwargs: Optional[Dict[str, Any]] = None,
-    gene_symbol_column_name: Optional[str] = None,
-    score_column_name: Optional[str] = None,
 ) -> Dict[str, float]:
     """Load a differential gene expression file with mouse measurements.
 
@@ -148,9 +127,9 @@ def get_mouse_scores(
 
 def get_human_scores(
     path: Union[Path, str, pd.DataFrame],
+    gene_symbol_column_name: str,
+    score_column_name: str,
     read_csv_kwargs: Optional[Dict[str, Any]] = None,
-    gene_symbol_column_name: Optional[str] = None,
-    score_column_name: Optional[str] = None,
 ) -> Dict[str, float]:
     """Load a differential gene expression file with human measurements.
 
@@ -182,9 +161,9 @@ def get_human_scores(
 
 def _get_species_scores(
     path: Union[Path, str, pd.DataFrame],
+    gene_symbol_column_name: str,
+    score_column_name: str,
     read_csv_kwargs: Optional[Dict[str, Any]] = None,
-    gene_symbol_column_name: Optional[str] = None,
-    score_column_name: Optional[str] = None,
     *,
     prefix=None,
     func=None,
@@ -193,14 +172,10 @@ def _get_species_scores(
         df = path
     else:
         df = pd.read_csv(path, **(read_csv_kwargs or {}))
-    if gene_symbol_column_name is None:
-        gene_symbol_column_name = _guess_symbol_col(df)
-    elif gene_symbol_column_name not in df.columns:
-        raise ValueError
-    if score_column_name is None:
-        score_column_name = _guess_score_col(df)
-    elif score_column_name not in df.columns:
-        raise ValueError
+    if gene_symbol_column_name not in df.columns:
+        raise ValueError(f"no column named {gene_symbol_column_name} in input data")
+    if score_column_name not in df.columns:
+        raise ValueError(f"no column named {score_column_name} in input data")
 
     if prefix is not None and func is not None:
         mapped_gene_symbol_column_name = f"{prefix}_id"

--- a/src/indra_cogex/client/enrichment/continuous.py
+++ b/src/indra_cogex/client/enrichment/continuous.py
@@ -464,11 +464,11 @@ def indra_downstream_gsea(
 
 GSEA_RETURN_COLUMNS = [
     "term",
-    "name",
-    "es",
-    "nes",
-    "pval",
-    "fdr",
+    "Name",
+    "ES",
+    "NES",
+    "NOM p-val",
+    "FDR q-val",
     "geneset_size",
     "matched_size",
 ]
@@ -528,9 +528,14 @@ def gsea(
         **kwargs,
     )
     res.res2d.index.name = "term"
+    # Full column list as of gseapy 1.1.2:
+    # Name, Term, ES, NES, NOM p-val, FDR q-val, FWER p-val, Tag %, Gene %,
+    # Lead_genes
     rv = res.res2d.reset_index()
     rv["name"] = rv["term"].map(curie_to_name)
+    rv["matched_size"] = rv['Tag %'].apply(lambda s: s.split('/')[0])
+    rv["geneset_size"] = rv['Tag %'].apply(lambda s: s.split('/')[1])
     rv = rv[GSEA_RETURN_COLUMNS]
     if not keep_insignificant:
-        rv = rv[rv["pval"] < alpha]
+        rv = rv[rv["NOM p-val"] < alpha]
     return rv

--- a/tests/test_sources/test_source_import.py
+++ b/tests/test_sources/test_source_import.py
@@ -24,7 +24,7 @@ def get_processor_classes():
             if name.startswith("_"):
                 continue
             obj = getattr(submodule, name)
-            if isinstance(obj, type) and issubclass(obj, Processor):
+            if isinstance(obj, type) and issubclass(obj, Processor) and obj not in yielded:
                 yielded.add(obj)
                 yield obj
 


### PR DESCRIPTION
This PR updates datatables to version 2.x, add an extension that enables download and adds a download button to the table outputs for the various gene/metabolite analysis pages.

I didn't have access to the DB last night to be able to test the code so still have a couple of things to check before this PR is ready.

ToDos:

- [x] Cosmetics: (better button name) 
- [x] Try out download on all tables and watch for errors
- [x] Results per page dropdown menu disappeared after upgrade, need to turn it back on again
- [x] Some tables are squeezed
- [x] Check continuous analysis output
- [x] Verify that the new columns used from the GSEA output are the ones we want (New columns names are `Name, Term, ES, NES, NOM p-val, FDR q-val, FWER p-val, Tag %, Gene %, Lead_genes` and changed at some point the past months, probably here: https://github.com/zqfang/GSEApy/compare/v1.0.4...v1.0.5) 

~One issue is the table for some tabs in the discrete GSEA are squeezed. It's still legible so it's probably OK for now if we need to deploy this immediately.~
