### PR TITLE
Pubmed rels debug

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,9 +3,19 @@ FROM labsyspharm/indra
 ARG INDRA_NEO4J_URL
 ARG INDRA_NEO4J_USER
 ARG INDRA_NEO4J_PASSWORD
+ARG MGI_VERSION
+ARG RGD_VERSION
 
 RUN pip3 install git+https://github.com/bgyori/indra_cogex.git#egg=indra_cogex[web,gunicorn,gsea] && \
-    python -m indra.ontology.bio build && \
-    python -c "from indra_cogex.client.enrichment.utils import build_caches; build_caches();"
+    python -m indra.ontology.bio build
+
+# Symlink the directories for the caches to this directory then run the docker build
+# Copy the pre-built pyobo caches for mouse (mgi) and rat (rgd) for pyobo
+COPY mgi/metadata.json /root/.data/pyobo/raw/mgi/
+COPY mgi/${MGI_VERSION} /root/.data/pyobo/raw/mgi/${MGI_VERSION}
+COPY rgd/metadata.json /root/.data/pyobo/raw/rgd/
+COPY rgd/${RGD_VERSION} /root/.data/pyobo/raw/rgd/${RGD_VERSION}
+
+RUN python -m indra_cogex.client.enrichment.utils --force
 
 ENTRYPOINT python -m indra_cogex.apps.cli --port 5000 --host "0.0.0.0" --with-gunicorn --workers 4 --timeout 300

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,10 +11,10 @@ RUN pip3 install git+https://github.com/bgyori/indra_cogex.git#egg=indra_cogex[w
 
 # Symlink the directories for the caches to this directory then run the docker build
 # Copy the pre-built pyobo caches for mouse (mgi) and rat (rgd) for pyobo
-COPY mgi/metadata.json /root/.data/pyobo/raw/mgi/
-COPY mgi/${MGI_VERSION} /root/.data/pyobo/raw/mgi/${MGI_VERSION}
-COPY rgd/metadata.json /root/.data/pyobo/raw/rgd/
-COPY rgd/${RGD_VERSION} /root/.data/pyobo/raw/rgd/${RGD_VERSION}
+RUN mkdir -p /root/.data/pyobo/raw/mgi/${MGI_VERSION}/cache/ && \
+    mkdir -p /root/.data/pyobo/raw/rgd/${RGD_VERSION}/cache/
+COPY mgi_names.tsv /root/.data/pyobo/raw/mgi/${MGI_VERSION}/cache/names.tsv
+COPY rgd_names.tsv /root/.data/pyobo/raw/rgd/${RGD_VERSION}/cache/names.tsv
 
 RUN python -m indra_cogex.client.enrichment.utils --force
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN mkdir -p /root/.data/pyobo/raw/mgi/${MGI_VERSION}/cache/ && \
 COPY mgi_names.tsv /root/.data/pyobo/raw/mgi/${MGI_VERSION}/cache/names.tsv
 COPY rgd_names.tsv /root/.data/pyobo/raw/rgd/${RGD_VERSION}/cache/names.tsv
 
+# Force rebuild the pickle caches for the GSEA and MSEA apps
 RUN python -m indra_cogex.client.enrichment.utils --force
 
 ENTRYPOINT python -m indra_cogex.apps.cli --port 5000 --host "0.0.0.0" --with-gunicorn --workers 4 --timeout 300

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,8 +9,9 @@ ARG RGD_VERSION
 RUN pip3 install git+https://github.com/bgyori/indra_cogex.git#egg=indra_cogex[web,gunicorn,gsea] && \
     python -m indra.ontology.bio build
 
-# Symlink the directories for the caches to this directory then run the docker build
-# Copy the pre-built pyobo caches for mouse (mgi) and rat (rgd) for pyobo
+# Copy the names.tsv files for the pre-built pyobo caches to this directory as
+# mg_names.tsv and rgd_names.tsv, respectively. This is necessary to avoid running the
+# full cache build process for these resources (which can take hours).
 RUN mkdir -p /root/.data/pyobo/raw/mgi/${MGI_VERSION}/cache/ && \
     mkdir -p /root/.data/pyobo/raw/rgd/${RGD_VERSION}/cache/
 COPY mgi_names.tsv /root/.data/pyobo/raw/mgi/${MGI_VERSION}/cache/names.tsv

--- a/import.sh
+++ b/import.sh
@@ -36,6 +36,7 @@ $NEO4J_PREFIX rm -rf $NEO4J_DATA/transactions/indra
 cat $NEO4J_CONFIG/neo4j.conf | grep "dbms\.default_database"
 
 
+# The import can take significant time (4+ hours) and memory.
 python -m indra_cogex.sources --process --assemble --run_import $COGEX_SUDO_ARG
 
 $NEO4J_PREFIX neo4j start

--- a/src/indra_cogex/apps/constants.py
+++ b/src/indra_cogex/apps/constants.py
@@ -43,6 +43,7 @@ edge_labels = {
     "variant_gene_association": "Variant Gene Associations",
     "variant_phenotype_association": "Variant Phenotype Associations",
     "has_activity": "Enzyme Annotations",
+    "published_by": "Journal-Publisher Associations",
 }
 
 INDRA_COGEX_WEB_LOCAL = (get_config("INDRA_COGEX_WEB_LOCAL") or "").lower() in {

--- a/src/indra_cogex/apps/constants.py
+++ b/src/indra_cogex/apps/constants.py
@@ -109,3 +109,8 @@ else:
         "and CLARE_PUSHER_CLUSTER."
     )
     pusher_app = None
+
+PYOBO_RESOURCE_FILE_VERSIONS = {
+    "mgi": "6.23",
+    "rgd": "2024-05-31",
+}

--- a/src/indra_cogex/apps/gla/fields.py
+++ b/src/indra_cogex/apps/gla/fields.py
@@ -49,7 +49,7 @@ source_field = RadioField(
         ("wikipathways", "WikiPathways"),
         ("phenotype", "HPO Phenotypes"),
         ("indra-upstream", "INDRA Upstream"),
-        ("indra-downstrea", "INDRA Downstream"),
+        ("indra-downstream", "INDRA Downstream"),
     ],
     default="go",
     description="The source of gene sets. Only one can be run at a time because"

--- a/src/indra_cogex/apps/templates/home.html
+++ b/src/indra_cogex/apps/templates/home.html
@@ -42,7 +42,13 @@
     <div class="col" style="margin-bottom: 1em">
         {% set count, suffix = format_number(counter[key]) %}
         <span class="count-{{ key }}" data-to="{{ count }}" data-time="1000"></span>{{ suffix }}<br/>
-        <small>{{ label|replace(" ", "&nbsp;")|safe }}</small>
+        <small>
+            {% if label %}
+                {{ label|replace(" ", "&nbsp;")|safe }}
+            {% else %}
+                {{ key }}
+            {% endif %}
+        </small>
     </div>
 {% endmacro %}
 

--- a/src/indra_cogex/assembly/__init__.py
+++ b/src/indra_cogex/assembly/__init__.py
@@ -81,7 +81,7 @@ class NodeAssembler:
                     self.conflicts.append(Conflict(data_key, previous_val, data_val))
                 else:
                     data[data_key] = data_val
-        return Node(db_ns, db_id, sorted(labels), data)
+        return Node(db_ns, db_id, sorted(labels), data, validate_data=True)
 
 
 class Conflict:

--- a/src/indra_cogex/client/enrichment/mla.py
+++ b/src/indra_cogex/client/enrichment/mla.py
@@ -52,6 +52,7 @@ def get_metabolomics_sets(
     -------
     : A dictionary of EC codes to set of ChEBI identifiers
     """
+    from indra_cogex.sources.ec import strip_ec_code
     rv = defaultdict(set)
 
     evidence_line = minimum_evidence_helper(minimum_evidence_count)
@@ -109,7 +110,8 @@ def get_metabolomics_sets(
     for hgnc_curie, chebi_curies in client.query_tx(query):
         hgnc_id = hgnc_curie.replace("hgnc:", "", 1)
         chebi_ids = {chebi_curie.split(":", 1)[1] for chebi_curie in chebi_curies}
-        for ec_code in hgnc_to_enzymes.get(hgnc_id, []):
+        for raw_ec_code in hgnc_to_enzymes.get(hgnc_id, []):
+            ec_code = strip_ec_code(raw_ec_code)
             ec_name = bio_ontology.get_name("ECCODE", ec_code)
             rv[ec_code, ec_name].update(chebi_ids)
     rv = dict(rv)

--- a/src/indra_cogex/client/enrichment/mla.py
+++ b/src/indra_cogex/client/enrichment/mla.py
@@ -9,7 +9,6 @@ from typing import Iterable, List, Mapping, Optional, Set, Tuple
 
 import indra.statements
 import pandas as pd
-import pyobo
 from indra.databases.hgnc_client import hgnc_to_enzymes
 from indra.ontology.bio import bio_ontology
 from indra.statements import stmts_from_json
@@ -111,7 +110,8 @@ def get_metabolomics_sets(
         hgnc_id = hgnc_curie.replace("hgnc:", "", 1)
         chebi_ids = {chebi_curie.split(":", 1)[1] for chebi_curie in chebi_curies}
         for ec_code in hgnc_to_enzymes.get(hgnc_id, []):
-            rv[ec_code, pyobo.get_name("ec", ec_code)].update(chebi_ids)
+            ec_name = bio_ontology.get_name("ECCODE", ec_code)
+            rv[ec_code, ec_name].update(chebi_ids)
     rv = dict(rv)
     print(f"got {len(rv)} enzymes to {_sum_values(rv)} chemicals")
     return rv

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -22,6 +22,7 @@ from typing import (
 import pystow
 from indra.databases.identifiers import get_ns_id_from_identifiers
 from indra.ontology.bio import bio_ontology
+from indra_cogex.apps.constants import PYOBO_RESOURCE_FILE_VERSIONS
 
 from indra_cogex.client.neo4j_client import Neo4jClient, autoclient
 from indra_cogex.representation import norm_id
@@ -752,6 +753,20 @@ def get_negative_stmt_sets(
     )
 
 
+def get_mouse_cache(force_cache_refresh: bool = False):
+    import pyobo
+    _ = pyobo.get_name_id_mapping(
+        "mgi", force=force_cache_refresh, version=PYOBO_RESOURCE_FILE_VERSIONS.get("mgi")
+    )
+
+
+def get_rat_cache(force_cache_refresh: bool = False):
+    import pyobo
+    _ = pyobo.get_name_id_mapping(
+        "rgd", force=force_cache_refresh, version=PYOBO_RESOURCE_FILE_VERSIONS.get("rgd")
+    )
+
+
 def build_caches(force_refresh: bool = False, lazy_loading_ontology: bool = False):
     """Call each gene set construction to build up cache
 
@@ -785,6 +800,11 @@ def build_caches(force_refresh: bool = False, lazy_loading_ontology: bool = Fals
     )
     get_negative_stmt_sets(force_cache_refresh=force_refresh)
     get_positive_stmt_sets(force_cache_refresh=force_refresh)
+    # Build the pyobo name-id mapping caches. Skip force refresh since the data
+    # isn't from CoGEx, rather change the version to download a new cache.
+    # See PYOBO_RESOURCE_FILE_VERSIONS in indra_cogex/apps/constants.py
+    get_mouse_cache()
+    get_rat_cache()
     logger.info("Finished building caches for gene set enrichment analysis.")
 
 

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -803,8 +803,10 @@ def build_caches(force_refresh: bool = False, lazy_loading_ontology: bool = Fals
     # Build the pyobo name-id mapping caches. Skip force refresh since the data
     # isn't from CoGEx, rather change the version to download a new cache.
     # See PYOBO_RESOURCE_FILE_VERSIONS in indra_cogex/apps/constants.py
-    get_mouse_cache()
-    get_rat_cache()
+    # NOTE: This will build all files for the pyobo caches, but we only need names.tsv
+    # Instead, we copy names.tsv files during docker build for each resource.
+    # get_mouse_cache()
+    # get_rat_cache()
     logger.info("Finished building caches for gene set enrichment analysis.")
 
 

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -61,6 +61,7 @@ def collect_gene_sets(
     background_gene_ids: Optional[Iterable[str]] = None,
     include_ontology_children: bool = False,
     cache_file: Optional[Path] = None,
+    force_cache_refresh: bool = False,
 ) -> Dict[Tuple[str, str], Set[str]]:
     """Collect gene sets based on the given query.
 
@@ -78,6 +79,9 @@ def collect_gene_sets(
         child terms using the indra ontology
     cache_file :
         The path to the cache file.
+    force_cache_refresh :
+        If True, the cache will be ignored and the query will be run again.
+        The current results will overwrite any existing cache.
 
     Returns
     -------
@@ -85,13 +89,22 @@ def collect_gene_sets(
         A dictionary whose keys that are 2-tuples of CURIE and name of each queried
         item and whose values are sets of HGNC gene identifiers (as strings)
     """
-    # If we are using caching and already have the cache loaded in memory
-    if cache_file is not None and cache_file.as_posix() in GENE_SET_CACHE:
+    # If we are using caching and already have the cache loaded in memory and
+    # we're not forcing a refresh
+    if (
+            cache_file is not None and
+            not force_cache_refresh and
+            cache_file.as_posix() in GENE_SET_CACHE
+    ):
         logger.info("Returning %s from in-memory cache" % cache_file.as_posix())
         res = GENE_SET_CACHE[cache_file.as_posix()]
     # If we are using caching but it's not in memory yet so we need to load
-    # it from a file
-    elif cache_file is not None and cache_file.exists():
+    # it from a file and we're not forcing a refresh
+    elif (
+            cache_file is not None and
+            not force_cache_refresh and
+            cache_file.exists()
+    ):
         logger.info("Loading %s" % cache_file.as_posix())
         with open(cache_file, "rb") as fh:
             res = pickle.load(fh)
@@ -162,6 +175,7 @@ def collect_genes_with_confidence(
     cache_file: Optional[Path] = None,
     background_gene_ids: Optional[Iterable[str]] = None,
     client: Neo4jClient,
+    force_cache_refresh: bool = False,
 ) -> Dict[Tuple[str, str], Dict[str, Tuple[float, int]]]:
     """Collect gene sets based on the given query.
 
@@ -177,6 +191,9 @@ def collect_genes_with_confidence(
         to query multiple times.
     client :
         The Neo4j client.
+    force_cache_refresh :
+        If True, the cache will be ignored and the query will be run again.
+        The current results will overwrite any existing cache.
 
     Returns
     -------
@@ -187,12 +204,19 @@ def collect_genes_with_confidence(
         the given HGNC gene.
     """
     # If we are using caching and already have the cache loaded in memory
-    if cache_file is not None and cache_file.as_posix() in GENE_SET_CACHE:
+    if (
+            cache_file is not None and
+            not force_cache_refresh and
+            cache_file.as_posix() in GENE_SET_CACHE):
         logger.info("Returning %s from in-memory cache" % cache_file.as_posix())
         res = GENE_SET_CACHE[cache_file.as_posix()]
     # If we are using caching but it's not in memory yet so we need to load
     # it from a file
-    elif cache_file is not None and cache_file.exists():
+    elif (
+            cache_file is not None and
+            not force_cache_refresh and
+            cache_file.exists()
+    ):
         logger.info("Loading %s" % cache_file.as_posix())
         with open(cache_file, "rb") as fh:
             curie_to_hgnc_ids = pickle.load(fh)
@@ -259,6 +283,7 @@ def get_go(
     *,
     background_gene_ids: Optional[Iterable[str]] = None,
     client: Neo4jClient,
+    force_cache_refresh: bool = False,
 ) -> Dict[Tuple[str, str], Set[str]]:
     """Get GO gene sets.
 
@@ -269,6 +294,9 @@ def get_go(
     background_gene_ids :
         List of HGNC gene identifiers for the background gene set. If not
         given, all genes with HGNC IDs are used as the background.
+    force_cache_refresh :
+        If True, the cache will be ignored and the query will be run again.
+        The current results will overwrite any existing cache.
 
     Returns
     -------
@@ -289,12 +317,16 @@ def get_go(
         cache_file=GO_GENE_SET_PATH,
         background_gene_ids=background_gene_ids,
         include_ontology_children=True,
+        force_cache_refresh=force_cache_refresh,
     )
 
 
 @autoclient()
 def get_wikipathways(
-    *, background_gene_ids: Optional[Iterable[str]] = None, client: Neo4jClient
+    *,
+    background_gene_ids: Optional[Iterable[str]] = None,
+    force_cache_refresh: bool = False,
+    client: Neo4jClient,
 ) -> Dict[Tuple[str, str], Set[str]]:
     """Get WikiPathways gene sets.
 
@@ -305,6 +337,9 @@ def get_wikipathways(
     background_gene_ids :
         List of HGNC gene identifiers for the background gene set. If not
         given, all genes with HGNC IDs are used as the background.
+    force_cache_refresh :
+        If True, the cache will be ignored and the query will be run again.
+        Any existing cache will be overwritten.
 
     Returns
     -------
@@ -325,12 +360,16 @@ def get_wikipathways(
         query=query,
         cache_file=WIKIPATHWAYS_GENE_SET_PATH,
         background_gene_ids=background_gene_ids,
+        force_cache_refresh=force_cache_refresh,
     )
 
 
 @autoclient()
 def get_reactome(
-    *, background_gene_ids: Optional[Iterable[str]] = None, client: Neo4jClient
+    *,
+    background_gene_ids: Optional[Iterable[str]] = None,
+    force_cache_refresh: bool = False,
+    client: Neo4jClient,
 ) -> Dict[Tuple[str, str], Set[str]]:
     """Get Reactome gene sets.
 
@@ -341,6 +380,8 @@ def get_reactome(
     background_gene_ids :
         List of HGNC gene identifiers for the background gene set. If not
         given, all genes with HGNC IDs are used as the background.
+    force_cache_refresh :
+        If True, the cache will be ignored and the query will be run again.
 
     Returns
     -------
@@ -361,12 +402,16 @@ def get_reactome(
         query=query,
         cache_file=REACTOME_GENE_SETS_PATH,
         background_gene_ids=background_gene_ids,
+        force_cache_refresh=force_cache_refresh,
     )
 
 
 @autoclient()
 def get_phenotype_gene_sets(
-    *, background_gene_ids: Optional[Iterable[str]] = None, client: Neo4jClient
+    *,
+    background_gene_ids: Optional[Iterable[str]] = None,
+    force_cache_refresh: bool = False,
+    client: Neo4jClient
 ) -> Dict[Tuple[str, str], Set[str]]:
     """Get HPO phenotype gene sets.
 
@@ -377,6 +422,9 @@ def get_phenotype_gene_sets(
     background_gene_ids :
         List of HGNC gene identifiers for the background gene set. If not
         given, all genes with HGNC IDs are used as the background.
+    force_cache_refresh :
+        If True, the cache will be ignored and the query will be run again.
+        Any existing cache will be overwritten.
 
     Returns
     -------
@@ -397,6 +445,7 @@ def get_phenotype_gene_sets(
         query=query,
         cache_file=HPO_GENE_SETS_PATH,
         background_gene_ids=background_gene_ids,
+        force_cache_refresh=force_cache_refresh,
     )
 
 
@@ -427,6 +476,7 @@ def get_entity_to_targets(
     background_gene_ids: Optional[Iterable[str]] = None,
     minimum_evidence_count: Optional[int] = 1,
     minimum_belief: Optional[float] = 0.0,
+    force_cache_refresh: bool = False,
 ) -> Dict[Tuple[str, str], Set[str]]:
     """Get a mapping from each entity in the INDRA database to the set of
     human genes that it regulates.
@@ -444,6 +494,9 @@ def get_entity_to_targets(
     minimum_belief :
         The minimum belief for a relationship to count it as a regulator.
         Defaults to 0.0 (i.e., cutoff not applied).
+    force_cache_refresh :
+        If True, the cache will be ignored and the query will be run again.
+        Any existing cache will be overwritten.
 
     Returns
     -------
@@ -470,6 +523,7 @@ def get_entity_to_targets(
         query=query,
         cache_file=TO_TARGETS_GENE_SETS_PATH,
         background_gene_ids=background_gene_ids,
+        force_cache_refresh=force_cache_refresh
     )
     return filter_gene_set_confidences(
         genes_with_confidence,
@@ -485,6 +539,7 @@ def get_entity_to_regulators(
     background_gene_ids: Optional[Iterable[str]] = None,
     minimum_evidence_count: Optional[int] = 1,
     minimum_belief: Optional[float] = 0.0,
+    force_cache_refresh: bool = False,
 ) -> Dict[Tuple[str, str], Set[str]]:
     """Get a mapping from each entity in the INDRA database to the set of
     human genes that are causally upstream of it.
@@ -502,6 +557,9 @@ def get_entity_to_regulators(
     minimum_belief :
         The minimum belief for a relationship to count it as a regulator.
         Defaults to 0.0 (i.e., cutoff not applied).
+    force_cache_refresh :
+        If True, the cache will be ignored and the query will be run again.
+        Any existing cache will be overwritten.
 
     Returns
     -------
@@ -528,6 +586,7 @@ def get_entity_to_regulators(
         query=query,
         cache_file=TO_REGULATORS_GENE_SETS_PATH,
         background_gene_ids=background_gene_ids,
+        force_cache_refresh=force_cache_refresh,
     )
     return filter_gene_set_confidences(
         genes_with_confidence,
@@ -602,6 +661,7 @@ def get_positive_stmt_sets(
     background_gene_ids: Optional[Iterable[str]] = None,
     minimum_evidence_count: Optional[int] = 1,
     minimum_belief: Optional[float] = 0.0,
+    force_cache_refresh: bool = False,
 ) -> Dict[Tuple[str, str], Set[str]]:
     """Get a mapping from each entity in the INDRA database to the set of
     entities that are causally downstream of human genes via an "activates"
@@ -620,6 +680,9 @@ def get_positive_stmt_sets(
     minimum_belief :
         The minimum belief for a relationship.
         Defaults to 0.0 (i.e., cutoff not applied).
+    force_cache_refresh
+        If True, the cache will be ignored and the query will be run again.
+        The current results will overwrite any existing cache.
 
     Returns
     -------
@@ -633,6 +696,7 @@ def get_positive_stmt_sets(
             client=client,
             cache_file=POSITIVES_GENE_SETS_PATH,
             background_gene_ids=background_gene_ids,
+            force_cache_refresh=force_cache_refresh,
         ),
         minimum_belief=minimum_belief,
         minimum_evidence_count=minimum_evidence_count,
@@ -646,6 +710,7 @@ def get_negative_stmt_sets(
     background_gene_ids: Optional[Iterable[str]] = None,
     minimum_evidence_count: Optional[int] = 1,
     minimum_belief: Optional[float] = 0.0,
+    force_cache_refresh: bool = False,
 ) -> Dict[Tuple[str, str], Set[str]]:
     """Get a mapping from each entity in the INDRA database to the set of
     entities that are causally downstream of human genes via an "inhibits"
@@ -660,10 +725,13 @@ def get_negative_stmt_sets(
         given, all genes with HGNC IDs are used as the background.
     minimum_evidence_count :
         The minimum number of evidences for a relationship.
-        Defaults to 1 (i.e., cutoff not applied.
+        Defaults to 1 (i.e., cutoff not applied).
     minimum_belief :
         The minimum belief for a relationship.
         Defaults to 0.0 (i.e., cutoff not applied).
+    force_cache_refresh :
+        If True, the cache will be ignored and the query will be run again.
+        The current results will overwrite any existing cache.
 
     Returns
     -------
@@ -677,20 +745,50 @@ def get_negative_stmt_sets(
             client=client,
             cache_file=NEGATIVES_GENE_SETS_PATH,
             background_gene_ids=background_gene_ids,
+            force_cache_refresh=force_cache_refresh,
         ),
         minimum_belief=minimum_belief,
         minimum_evidence_count=minimum_evidence_count,
     )
 
 
-def build_caches():
-    """Call each gene set constuction to build up cache,"""
+def build_caches(force_refresh: bool = False):
+    """Call each gene set construction to build up cache
+
+    Parameters
+    ----------
+    force_refresh :
+        If True, the cache will be ignored and the query will be run again.
+        The current results will overwrite any existing cache.
+    """
     logger.info("Building up caches for gene set enrichment analysis...")
-    get_go()
-    get_reactome()
-    get_wikipathways()
-    get_entity_to_targets(minimum_evidence_count=1, minimum_belief=0.0)
-    get_entity_to_regulators(minimum_evidence_count=1, minimum_belief=0.0)
-    get_negative_stmt_sets()
-    get_positive_stmt_sets()
+    get_go(force_cache_refresh=force_refresh)
+    get_reactome(force_cache_refresh=force_refresh)
+    get_wikipathways(force_cache_refresh=force_refresh)
+    get_entity_to_targets(
+        minimum_evidence_count=1,
+        minimum_belief=0.0,
+        force_cache_refresh=force_refresh
+    )
+    get_entity_to_regulators(
+        minimum_evidence_count=1,
+        minimum_belief=0.0,
+        force_cache_refresh=force_refresh
+    )
+    get_negative_stmt_sets(force_cache_refresh=force_refresh)
+    get_positive_stmt_sets(force_cache_refresh=force_refresh)
     logger.info("Finished building caches for gene set enrichment analysis.")
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="Build caches for gene set enrichment analysis."
+    )
+    parser.add_argument(
+        "-f", "--force-refresh",
+        action="store_true",
+        help="Force a refresh of the cache.",
+    )
+    args = parser.parse_args()
+    build_caches(force_refresh=args.force_refresh)

--- a/src/indra_cogex/client/enrichment/utils.py
+++ b/src/indra_cogex/client/enrichment/utils.py
@@ -752,15 +752,23 @@ def get_negative_stmt_sets(
     )
 
 
-def build_caches(force_refresh: bool = False):
+def build_caches(force_refresh: bool = False, lazy_loading_ontology: bool = False):
     """Call each gene set construction to build up cache
 
     Parameters
     ----------
     force_refresh :
-        If True, the cache will be ignored and the query will be run again.
-        The current results will overwrite any existing cache.
+        If True, the current cache will be ignored and the queries to get the
+        caches will be run again. The current results will overwrite any existing
+        cache. Default: False.
+    lazy_loading_ontology :
+        If True, the bioontology will be loaded lazily. If False, the bioontology
+        will be loaded immediately. The former is useful for testing and rapid development.
+        The latter is useful for production. Default: False.
     """
+    if not lazy_loading_ontology:
+        logger.info("Warming up bioontology...")
+        bio_ontology.initialize()
     logger.info("Building up caches for gene set enrichment analysis...")
     get_go(force_cache_refresh=force_refresh)
     get_reactome(force_cache_refresh=force_refresh)

--- a/src/indra_cogex/representation.py
+++ b/src/indra_cogex/representation.py
@@ -23,8 +23,6 @@ from indra.ontology.standardize import standardize_name_db_refs
 from indra.statements.agent import get_grounding
 from indra.statements import stmts_from_json, Statement
 
-from indra_cogex.sources.processor_util import data_validator
-
 NodeJson = Dict[str, Union[Collection[str], Dict[str, Any]]]
 RelJson = Dict[str, Union[Mapping[str, Any], Dict]]
 
@@ -63,6 +61,7 @@ class Node:
         self.labels = labels
 
         if data is not None and validate_data:
+            from indra_cogex.sources.processor_util import data_validator
             for header_key, data_value in data.items():
                 if ":" in header_key:
                     data_type = header_key.split(":")[1]

--- a/src/indra_cogex/sources/__init__.py
+++ b/src/indra_cogex/sources/__init__.py
@@ -23,7 +23,7 @@ from .interpro import InterproProcessor
 from .nih_reporter import NihReporterProcessor
 from .pathways import ReactomeProcessor, WikipathwaysProcessor
 from .processor import Processor
-from .pubmed import PubmedProcessor
+from .pubmed import PublicationProcessor, JournalProcessor
 from .sider import SIDERSideEffectProcessor
 from .wikidata import JournalPublisherProcessor
 from .gwas import GWASProcessor
@@ -44,7 +44,8 @@ __all__ = [
     "ChemblIndicationsProcessor",
     "SIDERSideEffectProcessor",
     "EvidenceProcessor",
-    "PubmedProcessor",
+    "PublicationProcessor",
+    "JournalProcessor",
     "HpDiseasePhenotypeProcessor",
     "HpPhenotypeGeneProcessor",
     "NihReporterProcessor",

--- a/src/indra_cogex/sources/cli.py
+++ b/src/indra_cogex/sources/cli.py
@@ -34,7 +34,7 @@ def _get_assembled_path(node_type: str) -> Path:
 @click.option(
     "--process",
     is_flag=True,
-    help="If true, builds all missing resouces.",
+    help="If true, builds all missing resources.",
 )
 @click.option(
     "--force_process",

--- a/src/indra_cogex/sources/ec/__init__.py
+++ b/src/indra_cogex/sources/ec/__init__.py
@@ -35,7 +35,7 @@ class HGNCEnzymeProcessor(Processor):
 
         self.enzymes = {}
         for enzyme_id in enzyme_to_hgncs:
-            stripped_id = _strip_ec_code(enzyme_id)
+            stripped_id = strip_ec_code(enzyme_id)
             self.enzymes[enzyme_id] = Node.standardized(
                 db_ns="ec-code",
                 db_id=stripped_id,
@@ -64,7 +64,7 @@ class HGNCEnzymeProcessor(Processor):
                 )
 
 
-def _strip_ec_code(code: str) -> str:
+def strip_ec_code(code: str) -> str:
     """Strips off trailing dashes from ec codes"""
     # Continue to strip off '.-' until name does not end with '.-'
     while code.endswith(".-"):

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -423,6 +423,8 @@ def validate_headers(headers: Iterable[str]) -> None:
             # Strip trailing '[]' for array types
             if dtype.endswith("[]"):
                 dtype = dtype[:-2]
+                if not dtype:
+                    raise ValueError(f"Data type value for header '{header}' is empty!")
 
             if dtype not in NEO4J_DATA_TYPES:
                 raise TypeError(

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -99,7 +99,7 @@ class Processor(ABC):
         """Run the CLI for this processor."""
         cls.get_cli()()
 
-    def dump(self) -> Tuple[Path, List[Node], Path]:
+    def dump(self) -> Tuple[Dict[str, Path], Dict[str, List[Node]], Path]:
         """Dump the contents of this processor to CSV files ready for use in ``neo4-admin import``."""
         node_paths, nodes = self._dump_nodes()
         edge_paths = self._dump_edges()
@@ -120,7 +120,7 @@ class Processor(ABC):
             cls.module.join(name="nodes_sample.tsv"),
         )
 
-    def _dump_nodes(self) -> Tuple[Path, List[Node]]:
+    def _dump_nodes(self) -> Tuple[Dict[str, Path], Dict[str, List[Node]]]:
         paths_by_type = {}
         nodes_by_type = defaultdict(list)
         # Get all the nodes

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -236,7 +236,7 @@ class JournalProcessor(PubmedProcessor):
             reader = csv.reader(fh)
             # Skip header
             next(reader)
-            # The file has more than 3500000 lines - a batch size of 1M is
+            # The file has more than 37M lines - a batch size of 1M is
             # reasonable
             batch_size = 1_000_000
             for batch in batch_iter(

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -213,12 +213,15 @@ class JournalProcessor(PubmedProcessor):
                 other = json.loads(other) or []
                 assert isinstance(other, list)
                 data = {
+                    # Should match journal_name in JournalPublisherProcessor
                     "name": journal_name,
                     "abbr_title": journal_abbrev,
+                    # Should match issn_l in JournalPublisherProcessor
                     "issn_l": issn_l,
                     "p_issn": p_issn,
                     "e_issn": e_issn,
-                    "issn_list:string[]": ";".join(other),
+                    # Rely on data from JournalPublisherProcessor for the issn_list
+                    # "issn_list:string[]": ";".join(other),
                 }
                 yield Node(
                     "NLM",

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -158,7 +158,7 @@ class PublicationProcessor(PubmedProcessor):
                 yield Node(
                     "PUBMED",
                     pmid,
-                    labels=[self.publication_node_type],
+                    labels=[PUBLICATION_NODE_TYPE],
                     data=data,
                 )
 

--- a/src/indra_cogex/sources/pubmed/__init__.py
+++ b/src/indra_cogex/sources/pubmed/__init__.py
@@ -1,3 +1,15 @@
+"""
+This module provides processors for PubMed data.
+
+Processors:
+    - PubmedProcessor: Base class for PubMed processors. This processor should not be
+    used directly.
+    - PublicationProcessor: Extracts publication nodes and relations between
+    publications and MeSH terms.
+    - JournalProcessor: Extracts journal nodes and relations between publications
+    and journals.
+"""
+
 import csv
 import gzip
 import json
@@ -27,13 +39,19 @@ logger = logging.getLogger(__name__)
 
 pubmed_base_url = "https://ftp.ncbi.nlm.nih.gov/pubmed/baseline/"
 pubmed_update_url = "https://ftp.ncbi.nlm.nih.gov/pubmed/updatefiles/"
+PUBLICATION_NODE_TYPE = "Publication"
+JOURNAL_NODE_TYPE = "Journal"
+
+
+__all__ = [
+    "PublicationProcessor",
+    "JournalProcessor",
+]
 
 
 class PubmedProcessor(Processor):
+    importable = False
     name = "pubmed"
-    publication_node_type = "Publication"
-    journal_node_type = "Journal"
-    node_types = [publication_node_type, journal_node_type]
 
     def __init__(self):
         # Maps MeSH terms to PMIDs
@@ -47,17 +65,61 @@ class PubmedProcessor(Processor):
         # Maps PMIDs to other text reference IDs
         self.text_refs_path = text_refs_fname
 
+    def __init_subclass__(cls, **kwargs):
+        # Modify the module path to include the name of this processor
+        cls.module = cls.module.module(cls.name)
+
+        # Now update paths for the node and relation data
+        cls.directory = cls.module.base
+        # These are nodes directly in the neo4j encoding
+        cls.nodes_path = cls.module.join(name="nodes.tsv.gz")
+        # These are nodes in the original INDRA-oriented representation
+        # needed for assembly
+        cls.nodes_indra_path = cls.module.join(name="nodes.pkl")
+        cls.edges_path = cls.module.join(name="edges.tsv.gz")
+
     def get_nodes(self) -> Iterable[Node]:
+        # Ensure cached files exist
         process_mesh_xml_to_csv(
             mesh_pmid_fpath=self.mesh_pmid_path,
             pmid_year_types_fpath=self.pmid_year_types_path,
             pmid_nlm_fpath=self.pmid_nlm_path,
             journal_info_fpath=self.journal_info_path,
         )
-        yield from self._yield_publication_nodes()
-        yield from self._yield_journal_nodes()
+        yield from self._get_nodes()
 
-    def _yield_publication_nodes(self) -> Iterable[Node]:
+    def get_relations(self) -> Iterable[List[Relation]]:
+        # Ensure cached files exist
+        process_mesh_xml_to_csv(
+            mesh_pmid_fpath=self.mesh_pmid_path,
+            pmid_year_types_fpath=self.pmid_year_types_path,
+            pmid_nlm_fpath=self.pmid_nlm_path,
+            journal_info_fpath=self.journal_info_path,
+        )
+        yield from self._get_relations()
+
+    def _dump_edges(self) -> Path:
+        # This overrides the default implementation in Processor because
+        # we want to process relations in batches
+        for bidx, batch in enumerate(self.get_relations()):
+            logger.info(f"Dumping relations batch {bidx}")
+            sample_path = None
+            write_mode = "at"
+            if bidx == 0:
+                sample_path = self.module.join(name="edges_sample.tsv")
+                write_mode = "wt"
+            edges_path = self._dump_edges_to_path(
+                batch, self.edges_path, sample_path, write_mode
+            )
+        return edges_path
+
+
+class PublicationProcessor(PubmedProcessor):
+    importable = True
+    name = "publication"
+    node_types = [PUBLICATION_NODE_TYPE]
+
+    def _get_nodes(self) -> Iterable[Node]:
         logger.info("Loading PMID year info from %s" % self.pmid_year_types_path)
         with gzip.open(self.pmid_year_types_path, "rt") as fh:
             pmid_years_pubtypes = {
@@ -100,54 +162,7 @@ class PubmedProcessor(Processor):
                     data=data,
                 )
 
-    def _yield_journal_nodes(self) -> Iterable[Node]:
-        # Load the journal info
-        logger.info("Loading journal info from %s" % self.journal_info_path)
-        with gzip.open(self.journal_info_path, "rt") as fh:
-            reader = csv.reader(fh, delimiter="\t")
-            next(reader)  # skip header
-            for (
-                    nlm_id,
-                    journal_name,
-                    journal_abbrev,
-                    issn,
-                    issn_l,
-                    p_issn,
-                    e_issn,
-                    other
-            ) in reader:
-                other = json.loads(other) or []
-                assert isinstance(other, list)
-                data = {
-                    "title": journal_name,
-                    "abbr_title": journal_abbrev,
-                    "issn_l": issn_l,
-                    "p_issn": p_issn,
-                    "e_issn": e_issn,
-                    "alternate_issn:string[]": ";".join(other),
-                }
-                yield Node(
-                    "NLM",
-                    nlm_id,
-                    labels=[self.journal_node_type],
-                    data=data,
-                )
-
-    def get_relations(self) -> Iterable[List[Relation]]:
-        # Ensure cached files exist
-        # Todo: Add force option to download files?
-        process_mesh_xml_to_csv(
-            mesh_pmid_fpath=self.mesh_pmid_path,
-            pmid_year_types_fpath=self.pmid_year_types_path,
-            pmid_nlm_fpath=self.pmid_nlm_path,
-            journal_info_fpath=self.journal_info_path,
-        )
-        logger.info("Generating mesh-pmid relations")
-        yield from self._yield_mesh_pmid_relations()
-        logger.info("Generating pmid-journal relations")
-        yield from self._yield_pmid_journal_relations()
-
-    def _yield_mesh_pmid_relations(self) -> Iterable[List[Relation]]:
+    def _get_relations(self) -> Iterable[List[Relation]]:
         with gzip.open(self.mesh_pmid_path, "rt") as fh:
             reader = csv.reader(fh)
             next(reader)  # skip header
@@ -173,13 +188,52 @@ class PubmedProcessor(Processor):
                     )
                 yield relations_batch
 
-    def _yield_pmid_journal_relations(self) -> Iterable[List[Relation]]:
+
+class JournalProcessor(PubmedProcessor):
+    importable = True
+    name = "journal"
+    node_types = [JOURNAL_NODE_TYPE]
+
+    def _get_nodes(self) -> Iterable[Node]:
+        # Load the journal info
+        logger.info("Loading journal info from %s" % self.journal_info_path)
+        with gzip.open(self.journal_info_path, "rt") as fh:
+            reader = csv.reader(fh, delimiter="\t")
+            next(reader)  # skip header
+            for (
+                    nlm_id,
+                    journal_name,
+                    journal_abbrev,
+                    issn,
+                    issn_l,
+                    p_issn,
+                    e_issn,
+                    other
+            ) in reader:
+                other = json.loads(other) or []
+                assert isinstance(other, list)
+                data = {
+                    "name": journal_name,
+                    "abbr_title": journal_abbrev,
+                    "issn_l": issn_l,
+                    "p_issn": p_issn,
+                    "e_issn": e_issn,
+                    "issn_list:string[]": ";".join(other),
+                }
+                yield Node(
+                    "NLM",
+                    nlm_id,
+                    labels=[JOURNAL_NODE_TYPE],
+                    data=data,
+                )
+
+    def _get_relations(self) -> Iterable[List[Relation]]:
         # Yield batches of relations
         with gzip.open(self.pmid_nlm_path, "rt") as fh:
             reader = csv.reader(fh)
             # Skip header
             next(reader)
-            # The file has more than 35000000 lines - a batch size of 1M is
+            # The file has more than 3500000 lines - a batch size of 1M is
             # reasonable
             batch_size = 1_000_000
             for batch in batch_iter(
@@ -197,21 +251,6 @@ class PubmedProcessor(Processor):
                         )
                     )
                 yield relations_batch
-
-    def _dump_edges(self) -> Path:
-        # This overrides the default implementation in Processor because
-        # we want to process relations in batches
-        for bidx, batch in enumerate(self.get_relations()):
-            logger.info(f"Dumping relations batch {bidx}")
-            sample_path = None
-            write_mode = "at"
-            if bidx == 0:
-                sample_path = self.module.join(name="edges_sample.tsv")
-                write_mode = "wt"
-            edges_path = self._dump_edges_to_path(
-                batch, self.edges_path, sample_path, write_mode
-            )
-        return edges_path
 
 
 def get_url_paths(url: str) -> Iterable[str]:
@@ -474,7 +513,8 @@ def process_mesh_xml_to_csv(
 
 def download_medline_pubmed_xml_resource(
     force: bool = False,
-    raise_http_error: bool = False
+    raise_http_error: bool = False,
+    raise_checksum_error: bool = False,
 ) -> None:
     """Downloads the medline and pubmed data from the NCBI ftp site.
 
@@ -487,6 +527,9 @@ def download_medline_pubmed_xml_resource(
     raise_http_error :
         If True, will raise error instead of skipping the file when
         downloading. Default: False.
+    raise_checksum_error :
+        If True, will raise error instead of skipping the file when
+        checksums do not match. Default: False.
     """
     for xml_file, stow, base_url in xml_path_generator(description="Download"):
         # Check if resource already exists
@@ -510,9 +553,11 @@ def download_medline_pubmed_xml_resource(
             r"[0-9a-z]+(?=\n)", md5_response.content.decode("utf-8")
         ).group()
         if actual_checksum != expected_checksum:
-            logger.warning(
-                f"Checksum does not match for {xml_file}. Is index out of bounds?"
-            )
+            err_msg = f"Checksum does not match for {xml_file}. Download timeout?"
+            if raise_checksum_error:
+                raise ValueError(err_msg)
+            logger.warning(err_msg)
+            # todo: better handling of bad downloads, don't use the file?
             continue
 
         # PyStow the file

--- a/src/indra_cogex/sources/pubmed/__main__.py
+++ b/src/indra_cogex/sources/pubmed/__main__.py
@@ -1,7 +1,17 @@
 """Run the PubMed processor using ``python -m indra_cogex.sources.pubmed``."""
+import click
+from more_click import verbose_option
 
-from . import PubmedProcessor
+from . import JournalProcessor, PublicationProcessor
+
+
+@click.command()
+@verbose_option
+@click.pass_context
+def _main(ctx: click.Context):
+    ctx.invoke(JournalProcessor.get_cli())
+    ctx.invoke(PublicationProcessor.get_cli())
 
 
 if __name__ == "__main__":
-    PubmedProcessor.cli()
+    _main()

--- a/src/indra_cogex/sources/wikidata/__init__.py
+++ b/src/indra_cogex/sources/wikidata/__init__.py
@@ -188,22 +188,23 @@ class JournalPublisherProcessor(WikiDataProcessor):
         cs_df = pd.read_excel(
             self.scopus_citescore_path, engine="openpyxl", sheet_name=0
         ).dropna(subset=["Source title"])
+
         # Set column types (if other than string)
-        cs_df["CiteScore"] = cs_df["CiteScore"].astype(float)
-        cs_df["2019-22 Citations"] = cs_df["2019-22 Citations"].astype(int)
-        cs_df["2019-22 Documents"] = cs_df["2019-22 Documents"].astype(int)
-        cs_df["% Cited"] = cs_df["% Cited"].astype(float)
-        cs_df["SNIP"] = cs_df["SNIP"].astype(float)
-        cs_df["SJR"] = cs_df["SJR"].astype(float)
+        cs_df["CiteScore"] = cs_df["CiteScore"].astype("Float64")
+        cs_df["2019-22 Citations"] = cs_df["2019-22 Citations"].astype("Int64")
+        cs_df["2019-22 Documents"] = cs_df["2019-22 Documents"].astype("Int64")
+        cs_df["% Cited"] = cs_df["% Cited"].astype("Float64")
+        cs_df["SNIP"] = cs_df["SNIP"].astype("Float64")
+        cs_df["SJR"] = cs_df["SJR"].astype("Float64")
 
         # Split the percentile column into three columns
         cs_df[["Percentile", "Rank", "Category"]] = (
             cs_df["Highest percentile"].str.split("\n", expand=True)
         )
         cs_df["Percentile"] = \
-            cs_df["Percentile"].str.replace("%", "").astype(float)
+            cs_df["Percentile"].str.replace("%", "").astype("Float64")
         # For rank, just keep the rank number (e.g. 2/80 -> 2) to allow sorting
-        cs_df["Rank"] = cs_df["Rank"].str.split("/").str[0].astype(int)
+        cs_df["Rank"] = cs_df["Rank"].str.split("/").str[0].astype("Int64")
 
         # Drop the original column
         cs_df = cs_df.drop(columns=["Highest percentile"])

--- a/src/indra_cogex/sources/wikidata/__init__.py
+++ b/src/indra_cogex/sources/wikidata/__init__.py
@@ -461,7 +461,7 @@ def _get_val(val):
     if (
         pd.isna(val) or
         isinstance(val, str) and not val.strip() or
-        isinstance(val, str) and val == "nan"
+        isinstance(val, str) and val.strip().lower() == "nan"
     ):
         return None
     else:

--- a/tests/test_ec.py
+++ b/tests/test_ec.py
@@ -1,11 +1,11 @@
-from indra_cogex.sources.ec import _strip_ec_code
+from indra_cogex.sources.ec import strip_ec_code
 
 
 def test_strip_ec_code():
     case1 = "3.4.24.-"
     case2 = "3.5.-.-"
 
-    stripped1 = _strip_ec_code(case1)
+    stripped1 = strip_ec_code(case1)
     assert stripped1 == "3.4.24"
-    stripped2 = _strip_ec_code(case2)
+    stripped2 = strip_ec_code(case2)
     assert stripped2 == "3.5"


### PR DESCRIPTION
This PR splits the `PubmedProcessor` into two separate processors: `PublicationProcessor` and `JournalProcessor`. This is done in order to not have a conflict in the (previously) common edges file.

Other updates:
- Resolve some data conflict in journal nodes from Pubmed and the wikidata `JournalPublisherProcessor`
- Various changes to catch NaN's in `JournalPublisherProcessor`
- Add option to validate data in `Node` creation, turned off by default, turned on for Node assembly
- Replace `pyobo` with `bio_ontology` where possible
- For cases where `pyobo` is used, specify version to avoid downloads of resource file when service is running
- Add cli for pickle caches

**Todo:**

- [x] Update Dockerfile to copy over pyobo resource files and to rebuild caches
- [ ] Rebuild and re-deploy service after merge
