### PR TITLE
Add optional source/target name for Relation

### DIFF
--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -868,8 +868,11 @@ class Neo4jClient:
             rel_type = neo4j_relation.type
             props = dict(neo4j_relation)
             source_ns, source_id = process_identifier(neo4j_relation.start_node["id"])
+            source_name = neo4j_relation.start_node.get("name")
             target_ns, target_id = process_identifier(neo4j_relation.end_node["id"])
-            rel = Relation(source_ns, source_id, target_ns, target_id, rel_type, props)
+            target_name = neo4j_relation.end_node.get("name")
+            rel = Relation(source_ns, source_id, target_ns, target_id, rel_type, props,
+                           source_name=source_name, target_name=target_name)
             relations.append(rel)
         return relations
 

--- a/src/indra_cogex/representation.py
+++ b/src/indra_cogex/representation.py
@@ -164,6 +164,8 @@ class Relation:
         target_id: str,
         rel_type: str,
         data: Optional[Mapping[str, Any]] = None,
+        source_name: Optional[str] = None,
+        target_name: Optional[str] = None,
     ):
         """Initialize the relation.
 
@@ -181,6 +183,10 @@ class Relation:
             The type of relation.
         data :
             An optional data dictionary associated with the relation.
+        source_name :
+            An optional name for the source node.
+        target_name :
+            An optional name for the target node.
         """
         self.source_ns = source_ns
         self.source_id = source_id
@@ -188,6 +194,8 @@ class Relation:
         self.target_id = target_id
         self.rel_type = rel_type
         self.data = data if data else {}
+        self.source_name = source_name
+        self.target_name = target_name
 
     def to_json(self) -> RelJson:
         """Serialize the relation to JSON format.
@@ -204,6 +212,8 @@ class Relation:
             "target_id": self.target_id,
             "rel_type": self.rel_type,
             "data": self.data,
+            "source_name": self.source_name,
+            "target_name": self.target_name,
         }
 
     def __str__(self):  # noqa:D105

--- a/tests/test_neo4j_client.py
+++ b/tests/test_neo4j_client.py
@@ -59,3 +59,16 @@ def test_process_identifier():
     assert process_identifier("hgnc:6871") == ("HGNC", "6871")
     assert process_identifier("chebi:1234") == ("CHEBI", "CHEBI:1234")
     assert process_identifier("uploc:SL-0086") == ("UPLOC", "SL-0086")
+
+
+@pytest.mark.nonpublic
+def test_get_source_relations():
+    nc = _get_client()
+    relations = nc.get_source_relations(
+        target=("HGNC", "9875"),
+        relation="indra_rel",
+        source_type='BioEntity',
+        target_type='BioEntity',
+    )
+
+    assert relations[0].target_name == "RASGRF1"


### PR DESCRIPTION
This PR extends the Relation class with additional attributes for the source node name and target node name. These can optionally be set on the client side (not really needed in the source processors since it's redundant in that context) when returning Relations as results of queries and is a convenient way to access names directly from the graph DB for the nodes over which the Relation is defined.