### PR TITLE
Handle list of HGNC IDs when parsing gene list

### DIFF
--- a/src/indra_cogex/analysis/gene_analysis.py
+++ b/src/indra_cogex/analysis/gene_analysis.py
@@ -298,7 +298,11 @@ def parse_gene_list(gene_list: Iterable[str]) -> Tuple[Dict[str, str], List[str]
             hgnc_ids.append(entry)
         else:  # probably a symbol
             hgnc_id = hgnc_client.get_current_hgnc_id(entry)
-            if hgnc_id:
+            # Handle special case where an outdated symbol
+            # corresponds to multiple current HGNC IDs
+            if isinstance(hgnc_id, list):
+                hgnc_ids.append(hgnc_id[0])
+            elif hgnc_id:
                 hgnc_ids.append(hgnc_id)
             else:
                 errors.append(entry)


### PR DESCRIPTION
This PR fixes a corner case in which an outdated gene symbol corresponds to more than one current HGNC ID which can occur when parsing input gene lists.