### PR TITLE
Replace norm_id with Bioregistry implementation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     pystow>=0.1.6
     bioregistry>=0.9.62
     pyobo>=0.9.1,<0.10.3
+    bioontologies<0.7
     numpy
     scipy
     statsmodels

--- a/src/indra_cogex/representation.py
+++ b/src/indra_cogex/representation.py
@@ -17,6 +17,9 @@ from typing import (
     Union,
 )
 import json
+
+import bioregistry
+
 from indra.databases import identifiers
 from indra.ontology.standardize import standardize_name_db_refs
 from indra.statements.agent import get_grounding
@@ -268,17 +271,7 @@ def norm_id(db_ns, db_id) -> str:
     :
         The normalized identifier.
     """
-    identifiers_ns = identifiers.get_identifiers_ns(db_ns)
-    identifiers_id = db_id
-    if not identifiers_ns:
-        identifiers_ns = db_ns.lower()
-    else:
-        ns_embedded = identifiers.identifiers_registry.get(identifiers_ns, {}).get(
-            "namespace_embedded"
-        )
-        if ns_embedded:
-            identifiers_id = identifiers_id[len(identifiers_ns) + 1:]
-    return f"{identifiers_ns}:{identifiers_id}"
+    return bioregistry.normalize_curie(f"{db_ns}:{db_id}")
 
 
 def triple_parameter_query(

--- a/src/indra_cogex/representation.py
+++ b/src/indra_cogex/representation.py
@@ -271,7 +271,12 @@ def norm_id(db_ns, db_id) -> str:
     :
         The normalized identifier.
     """
-    return bioregistry.normalize_curie(f"{db_ns}:{db_id}")
+    norm_curie = bioregistry.normalize_curie(f"{db_ns}:{db_id}")
+    # FIXME: temporarty patch while the content of the graph contains
+    # "ec-code" prefixes rather than "ec"
+    if norm_curie.startswith("ec:"):
+        norm_curie = 'ec-code:' + norm_curie[3:]
+    return norm_curie
 
 
 def triple_parameter_query(

--- a/tests/test_analysis_integration.py
+++ b/tests/test_analysis_integration.py
@@ -79,6 +79,8 @@ def test_discrete_analysis_with_indra():
         "phenotype",
         "indra-upstream",
         "indra-downstream",
+        "indra-upstream-kinases",
+        "indra-upstream-tfs",
     }
 
     assert expected_analyses == set(result.keys()), "Result should have all expected analyses"

--- a/tests/test_representation.py
+++ b/tests/test_representation.py
@@ -5,6 +5,8 @@ from indra_cogex.representation import node_query, norm_id, triple_query, \
 def test_norm_id():
     assert norm_id("UP", "P12345") == "uniprot:P12345"
     assert norm_id("CHEBI", "CHEBI:12345") == "chebi:12345"
+    assert norm_id("CHEBI", "12345") == "chebi:12345"
+    assert norm_id("chebi", "12345") == "chebi:12345"
 
 
 def test_node_query():


### PR DESCRIPTION
This PR replaces the `norm_id` function's implementation with a more general normalization function from the Bioregistry. Originally, norm_id was limited to converting standard "INDRA-style" namespace/identifier pairs to Bioregistry-style CURIEs but for several use cases it's useful to be able to handle more general non-INDRA-style namespace/identifier pairs as well which this achieves.