### PR TITLE
Implement getting evidences for given statements and MeSH term

### DIFF
--- a/src/indra_cogex/apps/queries_web/__init__.py
+++ b/src/indra_cogex/apps/queries_web/__init__.py
@@ -196,7 +196,8 @@ FUNCTION_CATEGORIES = {
             "get_stmts_for_mesh",
             "get_stmts_meta_for_stmt_hashes",
             "get_stmts_for_stmt_hashes",
-            "get_statements"
+            "get_statements",
+            "get_mesh_annotated_evidence",
         ]
     },
     'drug_targets': {

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -694,7 +694,27 @@ def get_mesh_annotated_evidence(
     include_child_terms: bool = True,
     *,
     client: Neo4jClient
-):
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Return Evidence data for a given MESH term and a given list of statement hashes.
+
+    Parameters
+    ----------
+    client :
+        The Neo4j client.
+    stmt_hashes :
+        The statement hashes to query evidence for.
+    mesh_term :
+        The MESH term to constrain evidences to.
+    include_child_terms :
+        If True, also match against the child MESH terms of the given MESH
+        term.
+
+    Returns
+    -------
+    :
+        A dictionary keyed by statement hash with each value being a list of
+        Evidence data dictionaries.
+    """
     if mesh_term[0] != "MESH":
         raise ValueError("Expected MESH term, got %s" % str(mesh_term))
     norm_mesh = norm_id(*mesh_term)

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -105,6 +105,7 @@ __all__ = [
     "get_drugs_for_sensitive_cell_line",
     "get_sensitive_cell_lines_for_drug",
     "is_cell_line_sensitive_to_drug",
+    "get_mesh_annotated_evidence",
 
     # Summary functions
     "get_node_counter",


### PR DESCRIPTION
This PR implements a new client function that lets you retrieve MeSH term-specific evidence for a list of statement hashes. This allows post-filtering results of subnetwork searches or any other endpoint that produces statements.