### PR TITLE
Expose source-target analysis

### DIFF
--- a/src/indra_cogex/analysis/cli.py
+++ b/src/indra_cogex/analysis/cli.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 import argparse
 import logging
+import pickle
 from datetime import datetime
+from pathlib import Path
 
 from indra_cogex.analysis.source_targets_explanation import explain_downstream
 
@@ -47,17 +49,23 @@ def main():
     # Create output directory if not specified
     if args.output_dir is None:
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        args.output_dir = f'analysis_results_{timestamp}'
+        output_dir = Path(f'./analysis_results_{timestamp}')
+    else:
+        output_dir = Path(args.output_dir)
 
     try:
         # Run the analysis using the existing explain_downstream function
-        explain_downstream(
+        result = explain_downstream(
             args.source,
             args.targets,
-            args.output_dir,
             id_type=args.id_type
         )
-        logger.info(f'Analysis results saved to {args.output_dir}')
+        # Save as pickle
+        # todo: save individual results i.e. plots, tables, etc. as separate files
+        output_dir.mkdir(parents=True, exist_ok=True)
+        with (output_dir / 'analysis_results.pkl').open("wb") as f:
+            pickle.dump(file=f, obj=result)
+        logger.info(f'Analysis results saved to {output_dir}')
 
     except Exception as e:
         logger.error(f'Analysis failed: {str(e)}')

--- a/src/indra_cogex/analysis/source_targets_explanation.py
+++ b/src/indra_cogex/analysis/source_targets_explanation.py
@@ -621,7 +621,9 @@ def explain_downstream(
     client :
         The client instance
     id_type : str
-        Type of identifiers provided. Either 'hgnc.symbol' or 'hgnc'
+        Type of identifiers provided. Either 'hgnc.symbol' or 'hgnc'. Use
+        'hgnc.symbol' if the source and targets fields are HGNC gene symbols, and
+        'hgnc' if they are HGNC IDs.
 
     Returns
     -------

--- a/src/indra_cogex/apps/queries_web/helpers.py
+++ b/src/indra_cogex/apps/queries_web/helpers.py
@@ -86,6 +86,9 @@ def process_result(result) -> Any:
     # Any fundamental type
     if isinstance(result, (int, str, bool, float)):
         return result
+    # Any single instance of something that can be converted to JSON
+    elif isinstance(result, Node):
+        return result.to_json()
     # Any dict query
     elif isinstance(result, (dict, Mapping, Counter)):
         res_dict = dict(result)
@@ -99,6 +102,9 @@ def process_result(result) -> Any:
         # Check for empty list
         if list_res and hasattr(list_res[0], "to_json"):
             list_res = [res.to_json() for res in list_res]
+        # Recursively process lists of lists
+        elif list_res and isinstance(list_res[0], list):
+            list_res = [process_result(res) for res in list_res]
         return list_res
     else:
         raise TypeError(f"Don't know how to process result of type {type(result)}")


### PR DESCRIPTION
This PR fixes some deployment-related bugs and adds `explain_downstream` (known as `Source-Target Gene Analysis` on the frontend) to the auto-generated rest api.


## Todo:

- [ ] Consider changing the name of the function `explain_downstream` to something more clear.
- [ ] The cli for `explain_downstream` should write its artifacts to individual files in the output folder, not just a pickle file (which is just a quick fix to not have the results not be saved at all).
- [ ] Currently `assemble_protein_stmt_htmls` is used to run the HtmlAssembler and get the HTML and pass that to the results, we should instead return statement data.