### PR TITLE
Clarify endpoints

### DIFF
--- a/src/indra_cogex/analysis/gene_analysis.py
+++ b/src/indra_cogex/analysis/gene_analysis.py
@@ -49,6 +49,9 @@ def discrete_analysis(
 ) -> Dict[str, pd.DataFrame]:
     """Perform discrete analysis on the provided genes.
 
+    Corresponding web-form based analysis can be found at:
+    https://discovery.indra.bio/gene/discrete
+
     Parameters
     ----------
     gene_list : List[str]
@@ -174,6 +177,9 @@ def signed_analysis(
 ) -> Optional[pd.DataFrame]:
     """Perform signed analysis using reverse causal reasoning
 
+    Corresponding web-form based analysis can be found at:
+    https://discovery.indra.bio/gene/signed
+
     Parameters
     ----------
     positive_genes : List[str]
@@ -235,6 +241,9 @@ def continuous_analysis(
     client: Neo4jClient
 ) -> pd.DataFrame:
     """Perform continuous gene set analysis on gene expression data.
+
+    Corresponding web-form based analysis is found at:
+    https://discovery.indra.bio/gene/continuous
 
     Parameters
     ----------
@@ -341,6 +350,9 @@ def kinase_analysis(
     client: Neo4jClient,
 ) -> pd.DataFrame:
     """Perform over-representation analysis on kinase-phosphosite relationships.
+
+    Corresponding web-form based analysis is found at:
+    https://discovery.indra.bio/gene/kinase
 
     Parameters
     ----------

--- a/src/indra_cogex/analysis/metabolite_analysis.py
+++ b/src/indra_cogex/analysis/metabolite_analysis.py
@@ -27,6 +27,9 @@ def metabolite_discrete_analysis(
 ) -> pd.DataFrame:
     """Perform discrete metabolite analysis and return results as a DataFrame
 
+    Corresponding web-form based analysis is found at:
+    https://discovery.indra.bio/metabolite/discrete
+
     Parameters
     ----------
     metabolites : List[str]

--- a/src/indra_cogex/analysis/metabolite_analysis.py
+++ b/src/indra_cogex/analysis/metabolite_analysis.py
@@ -25,7 +25,7 @@ def metabolite_discrete_analysis(
         *,
         client: Neo4jClient  # Client argument moved to the end as a keyword argument
 ) -> pd.DataFrame:
-    """Perform discrete metabolite analysis and return results as a DataFrame
+    """Perform discrete metabolite analysis
 
     Corresponding web-form based analysis is found at:
     https://discovery.indra.bio/metabolite/discrete

--- a/src/indra_cogex/analysis/source_targets_explanation.py
+++ b/src/indra_cogex/analysis/source_targets_explanation.py
@@ -613,7 +613,7 @@ def explain_downstream(
     """High-level function that handles input validation and runs the analysis.
 
     Corresponding web-form based analysis can be found at:
-    https://discovery.indra.bio/source-target/analysis
+    https://discovery.indra.bio/source_target/analysis
 
     Parameters
     ----------

--- a/src/indra_cogex/analysis/source_targets_explanation.py
+++ b/src/indra_cogex/analysis/source_targets_explanation.py
@@ -612,6 +612,9 @@ def explain_downstream(
 ) -> Dict:
     """High-level function that handles input validation and runs the analysis.
 
+    Corresponding web-form based analysis can be found at:
+    https://discovery.indra.bio/source-target/analysis
+
     Parameters
     ----------
     source : str

--- a/src/indra_cogex/apps/queries_web/helpers.py
+++ b/src/indra_cogex/apps/queries_web/helpers.py
@@ -236,7 +236,7 @@ def get_docstring(
         raise ValueError("Forgot to type annotate function")
 
     full_docstr = """{title}
-
+{extra_description}
 Parameters
 ----------
 {params}
@@ -251,6 +251,12 @@ Returns
     param_templ = "{name} : {typing}\n    {description}"
 
     ret_templ = "{typing}\n    {description}"
+
+    # See if there is an extra description in the docstring, after the first line
+    # but before the Parameters section. This is optional.
+    extra_description = ""
+    if parsed_doc.long_description and parsed_doc.long_description.strip():
+        extra_description += f"\n{parsed_doc.long_description.strip()}\n"
 
     # Get the parameters
     param_list = []
@@ -281,6 +287,7 @@ Returns
 
     return short, full_docstr.format(
         title=short,
+        extra_description=extra_description,
         params=params,
         return_str=return_str,
     )

--- a/src/indra_cogex/apps/templates/gene_analysis/continuous_form.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/continuous_form.html
@@ -4,4 +4,11 @@
 
 {% block header %}Continuous Gene Set Analysis{% endblock %}
 
-{% block lead %}This application performs GSEA on continuous data using INDRA CoGEx.{% endblock %}
+{% block lead %}
+    This application performs GSEA on continuous data using INDRA CoGEx.
+    <br>
+    <br>
+    The corresponding REST API endpoint for this analysis is <code>/api/continuous_analysis</code>.
+    You can find it on the <a href="/apidocs">API Docs</a> under the section 'Analysis
+    Queries'.
+{% endblock %}

--- a/src/indra_cogex/apps/templates/gene_analysis/discrete_form.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/discrete_form.html
@@ -27,4 +27,9 @@
     with a given GO term or the genes that are part of a given
     Reactome pathway). <i>p</i>-values are calculated using Fisher's exact
     test with different options available to adjust for multiple hypothesis testing.
+    <br>
+    <br>
+    The corresponding REST API endpoint for this analysis is
+    <code>/api/discrete_analysis</code>. You can find it on the <a href="/apidocs">API
+    Docs</a> under the section 'Analysis Queries'.
 {% endblock %}

--- a/src/indra_cogex/apps/templates/gene_analysis/kinase_form.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/kinase_form.html
@@ -20,4 +20,9 @@
         The analysis uses phosphorylation data from the INDRA database to identify upstream kinases
         that are likely responsible for the phosphorylation patterns in your dataset.
     </small>
+    <br>
+    <br>
+    The corresponding REST API endpoint for this analysis is <code>/api/kinase_analysis</code>.
+    You can find it on the <a href="/apidocs">API Docs</a> under the section 'Analysis
+    Queries'.
 {% endblock %}

--- a/src/indra_cogex/apps/templates/gene_analysis/signed_form.html
+++ b/src/indra_cogex/apps/templates/gene_analysis/signed_form.html
@@ -23,4 +23,9 @@
         <i>BMC Bioinformatics</i>, <b>14</b> (1), 340.
         <a href="https://doi.org/10.1186/1471-2105-14-340"><i class="fas fa-external-link-alt"></i></a>
     </small>
+    <br>
+    <br>
+    The corresponding REST API endpoint for this analysis is <code>/api/signed_analysis</code>.
+    You can find it on the <a href="/apidocs">API Docs</a> under the section 'Analysis
+    Queries'.
 {% endblock %}

--- a/src/indra_cogex/apps/templates/metabolite_analysis/discrete_form.html
+++ b/src/indra_cogex/apps/templates/metabolite_analysis/discrete_form.html
@@ -17,4 +17,9 @@
     This application performs metabolite set enrichment analysis using
     INDRA CoGEx, <i>p</i>-values are calculated using Fisher's exact
     test with different options available to adjust for multiple hypothesis testing.
+    <br>
+    <br>
+    The corresponding REST API endpoint for this analysis is <code>/api/metabolite_discrete_analysis</code>.
+    You can find it on the <a href="/apidocs">API Docs</a> under the section 'Analysis
+    Queries'.
 {% endblock %}

--- a/src/indra_cogex/apps/templates/source_target/source_target_form.html
+++ b/src/indra_cogex/apps/templates/source_target/source_target_form.html
@@ -20,21 +20,27 @@
 
 {% block lead %}
     This application analyzes relationships between a source gene and its downstream target genes using
-    INDRA CoGEx. The analysis reveals various types of biological relationships and shared mechanisms.<br>
-    <small>
+    INDRA CoGEx. The analysis reveals various types of biological relationships and shared mechanisms.
+    <br>
+    The corresponding REST API endpoint for the source-target queries is <code>/api/explain_downstream</code>.
+    You can find it on the <a href="/apidocs">API Docs</a> under the section 'Analysis Queries'.
+    <br>
+    This tool helps understand how genes interact and influence each other in biological networks.
+    <br>
+    {# ul cannot be inside a <p> tag, so we close it early, use div for the list,
+    and then start a new paragraph tag after the list #}
+    </p>
+    <div>
         The analysis includes:
-        <ul>
+        <ul style="font-size: 16px">
             <li>INDRA statements showing direct relationships and evidence</li>
             <li>Shared biological pathways from REACTOME and WikiPathways</li>
             <li>Protein family relationships</li>
             <li>Gene Ontology (GO) term analysis</li>
             <li>Upstream regulatory mechanisms</li>
         </ul>
-        This tool helps understand how genes interact and influence each other in biological networks.
-    </small>
-    <br>
-    <br>
-    The corresponding REST API endpoint for the source-target queries is
-    <code>/api/explain_downstream</code>. You can find it on the
-    <a href="/apidocs">API Docs</a> under the section 'Analysis Queries'.
+    </div>
+    {# New paragraph to match the enclosing one from outside the lead block (see
+    base_form.html #}
+    <p>
 {% endblock %}

--- a/src/indra_cogex/apps/templates/source_target/source_target_form.html
+++ b/src/indra_cogex/apps/templates/source_target/source_target_form.html
@@ -32,4 +32,9 @@
         </ul>
         This tool helps understand how genes interact and influence each other in biological networks.
     </small>
+    <br>
+    <br>
+    The corresponding REST API endpoint for the source-target queries is
+    <code>/api/explain_downstream</code>. You can find it on the
+    <a href="/apidocs">API Docs</a> under the section 'Analysis Queries'.
 {% endblock %}


### PR DESCRIPTION
This PR adds text to all analysis endpoint pages that spells out what their corresponding rest api endpoints are. It also adds mention of the form based pages for each of the backend analysis functions.