### PR TITLE
Fix docstrings for apidocs

### DIFF
--- a/src/indra_cogex/analysis/gene_analysis.py
+++ b/src/indra_cogex/analysis/gene_analysis.py
@@ -46,7 +46,7 @@ def discrete_analysis(
     background_gene_list: List[str] = None,
     *,
     client: Neo4jClient
-) -> Dict[str, Union[pd.DataFrame, None]]:
+) -> Dict[str, pd.DataFrame]:
     """Perform discrete analysis on the provided genes.
 
     Parameters
@@ -74,7 +74,7 @@ def discrete_analysis(
 
     Returns
     -------
-    Dict[str, pd.DataFrame | None]
+    Dict[str, pd.DataFrame]
         A dict with results per analysis type in the form of a DataFrame or None
         if an error occurs or no results are found.
     """
@@ -331,7 +331,7 @@ def continuous_analysis(
 
 @autoclient()
 def kinase_analysis(
-    phosphosite_list: Iterable[str],
+    phosphosite_list: List[str],
     alpha: float = 0.05,
     keep_insignificant: bool = False,
     background: Optional[Collection[str]] = None,
@@ -344,7 +344,7 @@ def kinase_analysis(
 
     Parameters
     ----------
-    phosphosite_list : Iterable[str]
+    phosphosite_list : List[str]
         List of phosphosites in the format "gene-site" or "UniProtID-site" (e.g., "MAPK1-Y187" or "P23443-T412").
     alpha : float, default=0.05
         Significance threshold for ORA.
@@ -395,7 +395,7 @@ def kinase_analysis(
     )
 
 
-def parse_gene_list(gene_list: Iterable[str]) -> Tuple[Dict[str, str], List[str]]:
+def parse_gene_list(gene_list: List[str]) -> Tuple[Dict[str, str], List[str]]:
     """Parse gene list"""
     hgnc_ids = []
     errors = []
@@ -439,7 +439,7 @@ def is_valid_phosphosite(site: str) -> bool:
 
 
 def parse_phosphosite_list(
-    phosphosite_list: Iterable[Tuple[str, str]]
+    phosphosite_list: List[Tuple[str, str]]
 ) -> Tuple[List[Tuple[str, str]], List[str]]:
     """Convert UniProt IDs to gene symbols and validate phosphosites."""
     phosphosites = []

--- a/src/indra_cogex/apps/bioentity/api.py
+++ b/src/indra_cogex/apps/bioentity/api.py
@@ -131,9 +131,14 @@ class UniprotIdsFromUniprotMnemonicIds(Resource):
         convert each mnemonic ID to a UniProt ID. Then, it adds the mapping from the
         mnemonic ID to the UniProt ID to the result.
 
+        Parameters
+        ----------
+        uniprot_mnemonic_ids : List[str]
+            A list of  uniprot mnemonic identifiers to map to uniprot identifiers.
+
         Returns
         -------
-        :
+        mapping : Dict[str, str]
             A dictionary mapping UniProt mnemonic IDs to UniProt IDs.
         """
         uniprot_mnemonic_ids = request.json["uniprot_mnemonic_ids"]
@@ -164,9 +169,14 @@ class HgncIdsFromUniprotIds(Resource):
         "uniprot_ids". It returns a dictionary mapping each UniProt ID to its
         corresponding HGNC ID, if available.
 
+        Parameters
+        ----------
+        uniprot_ids : List[str]
+            A list of uniprot identifiers to map to HGNC identifiers.
+
         Returns
         -------
-        :
+        mapping : Dict[str, str]
             A dictionary where keys are UniProt IDs and values are HGNC IDs.
         """
         uniprot_ids = request.json["uniprot_ids"]
@@ -197,9 +207,14 @@ class HgncNamesFromHgncIds(Resource):
         "hgnc_ids". It retrieves the corresponding HGNC names using the `hgnc_client`
         and returns a dictionary mapping each HGNC ID to its name.
 
+        Parameters
+        ----------
+        hgnc_ids : List[str]
+            A list if HGNC identifiers to map to gene names
+
         Returns
         -------
-        :
+        mapping : Dict[str, str]
             A dictionary where keys are HGNC IDs and values are HGNC names.
         """
         hgnc_ids = request.json["hgnc_ids"]
@@ -231,9 +246,14 @@ class CheckIfKinase(Resource):
         `hgnc_client.is_kinase` method and returns a mapping of each gene to a boolean
         indicating whether it is a kinase.
 
+        Parameters
+        ----------
+        genes : List[str]
+            A list of gene names to check
+
         Returns
         -------
-        :
+        mapping : Dict[str, bool]
             A dictionary where the keys are gene names and the values are booleans
             indicating whether each gene is a kinase.
         """
@@ -260,15 +280,20 @@ class CheckIfPhosphatase(Resource):
     def post(self):
         """Determines if the given genes are phosphatases.
 
-        This method expects a JSON payload with a list of gene identifiers under the
+        This method expects a JSON payload with a list of gene names under the
         key "genes". It checks each gene to determine if it is a phosphatase using the
         `hgnc_client.is_phosphatase` method. The result is a dictionary mapping each
         gene to a boolean indicating whether it is a phosphatase.
 
+        Parameters
+        ----------
+        genes : List[str]
+            A list of gene names to check is they are phosphotases.
+
         Returns
         -------
-        :
-            A dictionary where keys are gene identifiers and values are booleans
+        mapping : Dict[str, bool]
+            A dictionary where keys are gene names and values are booleans
             indicating if the gene is a phosphatase.
         """
         genes = request.json["genes"]
@@ -299,9 +324,14 @@ class CheckIfTranscriptionFactor(Resource):
         `hgnc_client.is_transcription_factor` method and returns a mapping of genes
         to their transcription factor status.
 
+        Parameters
+        ----------
+        genes : List[str]
+            A list of gene names to check if they are transcription factors.
+
         Returns
         -------
-        :
+        mapping : Dict[str, bool]
             A dictionary where keys are gene names and values are booleans indicating
             whether the gene is a transcription factor.
         """

--- a/src/indra_cogex/apps/queries_web/__main__.py
+++ b/src/indra_cogex/apps/queries_web/__main__.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 
-"""Run the query web app with ``python -m indra_cogex.apps.queries_web``."""
+"""Run the query web app with ``python -m indra_cogex.apps.queries_web``.
+
+This allows the queries web application to be run as a standalone module, which will
+skip the typical startup activities associated with running the full INDRA-Cogex application.
+In this mode, most pages, including the landing page, will not be available, but it's
+still possible to navigate directly to the api docs at /apidocs and investigate the API.
+"""
 
 from indra_cogex.apps.queries_web.cli import cli
 

--- a/src/indra_cogex/apps/queries_web/helpers.py
+++ b/src/indra_cogex/apps/queries_web/helpers.py
@@ -11,9 +11,11 @@ from typing import (
     Type,
     Optional,
     Set,
+    Union,
 )
 
 import pandas as pd
+import pandas.core.frame
 from docstring_parser import parse
 from indra.statements import Agent, Evidence, Statement
 
@@ -139,6 +141,7 @@ def get_web_return_annotation(sig: Signature) -> Type:
     # Agent -> Dict[str, Any]
     # Mapping[str, Iterable[indra.statements.agent.Agent]]
     #   -> Dict[str, List[Dict[str, Any]]]
+    # pandas.core.frame.DataFrame -> List[Dict[str, Any]]
 
     if return_annotation is Iterable[Node]:
         return List[Dict[str, Any]]
@@ -158,6 +161,9 @@ def get_web_return_annotation(sig: Signature) -> Type:
         return Dict[str, Any]
     elif return_annotation is Mapping[str, Iterable[Agent]]:
         return Dict[str, List[Dict[str, Any]]]
+    elif return_annotation is pandas.core.frame.DataFrame:
+        # Has [str, int, float] columns
+        return List[Dict[str, Union[str, int, float]]]
     else:
         return return_annotation
 

--- a/src/indra_cogex/apps/queries_web/helpers.py
+++ b/src/indra_cogex/apps/queries_web/helpers.py
@@ -147,10 +147,13 @@ def get_web_return_annotation(sig: Signature) -> Type:
     #   -> Dict[str, List[Dict[str, Any]]]
     # pandas.core.frame.DataFrame -> List[Dict[str, Any]]
 
+    # Todo: is there a way to handle this recursively for nested types?
     if return_annotation is Iterable[Node]:
         return ListJSON
     elif return_annotation is bool:
         return Dict[str, bool]
+    elif return_annotation is Mapping[str, List[str]]:
+        return Dict[str, List[str]]
     elif (
         return_annotation is Dict[int, Iterable[Evidence]] or
         return_annotation is Dict[int, List[Evidence]]
@@ -190,9 +193,14 @@ def get_web_return_annotation(sig: Signature) -> Type:
     elif return_annotation is pandas.core.frame.DataFrame:
         # Has [str, int, float] columns
         return List[Dict[str, Union[str, int, float]]]
+    elif return_annotation is Dict[str, pandas.core.frame.DataFrame]:
+        return Dict[str, List[Dict[str, Union[str, int, float]]]]
     # indra_subnetwork_go
     elif return_annotation == Union[List[Statement], Tuple[List[Statement], Dict[int, Dict[str, int]]]]:
         return Union[ListJSON, Tuple[ListJSON, Dict[int, Dict[str, int]]]]
+    # get_stmts_for_stmt_hashes
+    elif return_annotation == Union[List[Statement], Tuple[List[Statement], Mapping[int, int]]]:
+        return Union[ListJSON, Tuple[ListJSON, Dict[int, int]]]
     else:
         return return_annotation
 

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -445,7 +445,7 @@ def get_pathways_for_gene(
 
 @autoclient()
 def get_shared_pathways_for_genes(
-    genes: Iterable[Tuple[str, str]], *, client: Neo4jClient
+    genes: List[Tuple[str, str]], *, client: Neo4jClient
 ) -> Iterable[Node]:
     """Return the shared pathways for the given list of genes.
 
@@ -982,7 +982,7 @@ def get_evidences_for_stmt_hash(
 
 @autoclient()
 def get_evidences_for_stmt_hashes(
-    stmt_hashes: Iterable[int],
+    stmt_hashes: List[int],
     *,
     client: Neo4jClient,
     limit: Optional[str] = None,
@@ -1141,7 +1141,7 @@ def get_stmts_for_mesh(
     evidence_limit: int = 10,
     include_db_evidence: bool = True,
     **kwargs,
-) -> Union[Tuple[List[Statement], Mapping[int, int]], Tuple[List[Statement], None]]:
+) -> Union[Tuple[List[Statement], Mapping[int, int]], List[Statement]]:
     """Return the statements with evidence for the given MESH ID.
 
     Parameters
@@ -1180,7 +1180,7 @@ def get_stmts_for_mesh(
 
 @autoclient()
 def get_stmts_meta_for_stmt_hashes(
-    stmt_hashes: Iterable[int],
+    stmt_hashes: List[int],
     *,
     client: Neo4jClient,
 ) -> Iterable[Relation]:
@@ -1211,7 +1211,7 @@ def get_stmts_meta_for_stmt_hashes(
 
 @autoclient()
 def get_stmts_for_stmt_hashes(
-    stmt_hashes: Iterable[int],
+    stmt_hashes: List[int],
     *,
     evidence_map: Optional[Dict[int, List[Evidence]]] = None,
     client: Neo4jClient,
@@ -1672,7 +1672,7 @@ def get_drugs_for_target(
 
 @autoclient()
 def get_drugs_for_targets(
-    targets: Iterable[Tuple[str, str]], *, client: Neo4jClient
+    targets: List[Tuple[str, str]], *, client: Neo4jClient
 ) -> Mapping[str, Iterable[Agent]]:
     """Return the drugs targeting each of the given targets.
 
@@ -1732,7 +1732,7 @@ def get_targets_for_drug(
 
 @autoclient()
 def get_targets_for_drugs(
-    drugs: Iterable[Tuple[str, str]], *, client: Neo4jClient
+    drugs: List[Tuple[str, str]], *, client: Neo4jClient
 ) -> Mapping[str, Iterable[Agent]]:
     """Return the proteins targeted by each of the given drugs
 
@@ -1789,7 +1789,7 @@ def is_drug_target(
 
 
 def _get_ev_dict_from_hash_ev_query(
-    result: Optional[Iterable[List[Union[int, str]]]] = None,
+    result: Optional[List[List[Union[int, str]]]] = None,
     remove_medscan: bool = True,
 ) -> Dict[int, List[Evidence]]:
     """Assumes result is an Iterable of pairs of [hash, evidence_json]"""
@@ -1823,7 +1823,7 @@ def _get_node_from_stmt_relation(
 
 
 def _filter_out_medscan_evidence(
-    ev_list: Iterable[Dict[str, Dict]], remove_medscan: bool = True
+    ev_list: List[Dict[str, Dict]], remove_medscan: bool = True
 ) -> List[Evidence]:
     """Filter out Evidence JSONs containing evidence from medscan."""
     return [
@@ -1889,7 +1889,7 @@ def get_cell_types_for_marker(
 @autoclient()
 def is_marker_for_cell_type(
     marker: Tuple[str, str], cell_type: Tuple[str, str], *, client: Neo4jClient
-) -> List[Any]:
+) -> bool:
     """Return True if the marker is associated with the given cell type.
 
     Parameters
@@ -1974,7 +1974,7 @@ def get_diseases_for_phenotype(
 @autoclient()
 def has_phenotype(
     disease: Tuple[str, str], phenotype: Tuple[str, str], *, client: Neo4jClient
-) -> List[Any]:
+) -> bool:
     """Return True if the disease has the given phenotype.
 
     Parameters
@@ -2137,7 +2137,7 @@ def get_journals_for_publisher(
 @autoclient()
 def is_journal_published_by(
     journal: Tuple[str, str], publisher: Tuple[str, str], *, client: Neo4jClient
-) -> List[Any]:
+) -> bool:
     """Check if a journal is published by a specific publisher.
 
     Parameters
@@ -2865,7 +2865,7 @@ def get_drugs_for_indication(
 @autoclient()
 def drug_has_indication(
     molecule: Tuple[str, str], indication: Tuple[str, str], *, client: Neo4jClient
-) -> List[Any]:
+) -> bool:
     """Check if a molecule is associated with an indication in ChEMBL data.
 
     Parameters
@@ -2922,7 +2922,7 @@ def get_codependents_for_gene(
 @autoclient()
 def gene_has_codependency(
     gene1: Tuple[str, str], gene2: Tuple[str, str], *, client: Neo4jClient
-) -> List[Any]:
+) -> bool:
     """Check if two genes are codependent according to DepMap data.
 
     Parameters

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -1,7 +1,7 @@
 """Queries that generate statement subnetworks."""
 
 import json
-from typing import Any, Iterable, List, Tuple, Union, Dict
+from typing import Any, List, Tuple, Union, Dict
 import logging
 
 from indra.statements import Statement
@@ -23,7 +23,7 @@ __all__ = [
 
 @autoclient()
 def indra_subnetwork_relations(
-    nodes: Iterable[Tuple[str, str]], *, client: Neo4jClient, include_db_evidence: bool = True
+    nodes: List[Tuple[str, str]], *, client: Neo4jClient, include_db_evidence: bool = True
 ) -> List[Relation]:
     """Return the subnetwork induced by the given nodes as a set of Relations.
 
@@ -54,7 +54,7 @@ def indra_subnetwork_relations(
 
 @autoclient()
 def indra_subnetwork_meta(
-    nodes: Iterable[Tuple[str, str]], *, client: Neo4jClient
+    nodes: List[Tuple[str, str]], *, client: Neo4jClient
 ) -> List[List[Any]]:
     """Return the subnetwork induced by the given nodes as a list of metadata
     on relations.
@@ -91,7 +91,7 @@ def indra_subnetwork_meta(
 
 @autoclient()
 def indra_subnetwork(
-    nodes: Iterable[Tuple[str, str]],
+    nodes: List[Tuple[str, str]],
     *,
     client: Neo4jClient,
     include_db_evidence: bool = True,
@@ -134,7 +134,7 @@ def indra_subnetwork(
 
 @autoclient()
 def indra_mediated_subnetwork(
-    nodes: Iterable[Tuple[str, str]],
+    nodes: List[Tuple[str, str]],
     *,
     client: Neo4jClient,
     order_by_ev_count: bool = False,
@@ -170,7 +170,7 @@ def indra_mediated_subnetwork(
 
 @autoclient()
 def indra_shared_downstream_subnetwork(
-    nodes: Iterable[Tuple[str, str]],
+    nodes: List[Tuple[str, str]],
     *,
     client: Neo4jClient,
     order_by_ev_count: bool = False,
@@ -206,7 +206,7 @@ def indra_shared_downstream_subnetwork(
 
 @autoclient()
 def indra_shared_upstream_subnetwork(
-    nodes: Iterable[Tuple[str, str]],
+    nodes: List[Tuple[str, str]],
     *,
     client: Neo4jClient,
     order_by_ev_count: bool = False,
@@ -242,7 +242,7 @@ def indra_shared_upstream_subnetwork(
 
 def get_two_step_subnetwork(
     *,
-    nodes: Iterable[Tuple[str, str]],
+    nodes: List[Tuple[str, str]],
     client: Neo4jClient,
     first_forward: bool = True,
     second_forward: bool = True,


### PR DESCRIPTION
This PR updates type annotations and return type annotation handling for the apidocs. This is done in an effort to root out any mention of Python objects and to as a great extent as possible use generic/JSON compatible types in the apidocs.