### PR TITLE
Add network graph endpoints and vis.js integration for displaying network visualizations for GO and Subnetwork Explorers

### DIFF
--- a/src/indra_cogex/apps/curator/explorer_blueprint.py
+++ b/src/indra_cogex/apps/curator/explorer_blueprint.py
@@ -109,6 +109,8 @@ def explore_go(term: str):
         """,
         include_db_evidence=include_db_evidence,
         source_counts=source_counts,
+        prefix="go",
+        identifier=term,
     )
 
 
@@ -120,6 +122,8 @@ def _enrich_render_statements(
     no_stmts_message: Optional[str] = None,
     include_db_evidence: bool = False,
     source_counts: Optional[Mapping[int, Mapping[str, int]]] = None,
+    prefix: Optional[str] = None,
+    identifier: Optional[str] = None,
 ) -> Response:
     if curations is None:
         curations = curation_cache.get_curation_cache()
@@ -146,7 +150,9 @@ def _enrich_render_statements(
         source_counts_dict=source_counts,
         description=description,
         no_stmts_message=no_stmts_message,
-        include_db_evidence=include_db_evidence
+        include_db_evidence=include_db_evidence,
+        prefix=prefix,
+        identifier=identifier
         # no limit necessary here since it was already applied above
     )
 
@@ -812,6 +818,8 @@ def subnetwork():
             no_stmts_message="No statements found for the given nodes.",
             include_db_evidence=include_db_evidence,
             source_counts=source_counts,
+            prefix="subnetwork",
+            identifier=','.join(f"{ns}:{id}" for ns, id in nodes)
         )
 
     # If no nodes provided, just render the form

--- a/src/indra_cogex/apps/queries_web/__init__.py
+++ b/src/indra_cogex/apps/queries_web/__init__.py
@@ -201,7 +201,8 @@ FUNCTION_CATEGORIES = {
             "get_stmts_meta_for_stmt_hashes",
             "get_stmts_for_stmt_hashes",
             "get_statements",
-            "get_mesh_annotated_evidence"
+            "get_mesh_annotated_evidence",
+            "get_network"
         ]
     },
     'drug_targets': {
@@ -489,6 +490,11 @@ examples_dict = {
     "indication": fields.List(fields.String, example=["mesh", "D002318"]),
     # For EC
     "enzyme": fields.List(fields.String, example=["ec-code", "3.4.21.105"]),
+    "network_type": fields.String(example="paper"),
+    "identifier": {
+        "get_network": fields.Raw(example=["PUBMED", "23356518"]),
+        "default": fields.Raw(example=["PUBMED", "23356518"])
+    },
 }
 
 # Parameters to always skip in the examples and in the documentation

--- a/src/indra_cogex/apps/queries_web/__init__.py
+++ b/src/indra_cogex/apps/queries_web/__init__.py
@@ -201,10 +201,7 @@ FUNCTION_CATEGORIES = {
             "get_stmts_meta_for_stmt_hashes",
             "get_stmts_for_stmt_hashes",
             "get_statements",
-            "get_mesh_annotated_evidence",
-            "get_network_for_paper",
-            "get_network_for_go_term",
-            "get_network_for_subnetwork"
+            "get_mesh_annotated_evidence"
         ]
     },
     'drug_targets': {

--- a/src/indra_cogex/apps/queries_web/__init__.py
+++ b/src/indra_cogex/apps/queries_web/__init__.py
@@ -202,7 +202,9 @@ FUNCTION_CATEGORIES = {
             "get_stmts_for_stmt_hashes",
             "get_statements",
             "get_mesh_annotated_evidence",
-            "get_network_for_paper"
+            "get_network_for_paper",
+            "get_network_for_go_term",
+            "get_network_for_subnetwork"
         ]
     },
     'drug_targets': {

--- a/src/indra_cogex/apps/templates/data_display/data_display_base.html
+++ b/src/indra_cogex/apps/templates/data_display/data_display_base.html
@@ -86,17 +86,17 @@
                 </div>
             {% endif %}
             {% if is_proteocentric %}
-            <div class="card-body">
-                <div class="form-check mb-3">
-                    <input type="checkbox" class="form-check-input" id="include_db_evidence"
-                           v-model="include_db_evidence" @change="updateIncludeDbEvidence">
-                    <label class="form-check-label" for="include_db_evidence">Include database evidence</label>
+                <div class="card-body">
+                    <div class="form-check mb-3">
+                        <input type="checkbox" class="form-check-input" id="include_db_evidence"
+                               v-model="include_db_evidence" @change="updateIncludeDbEvidence">
+                        <label class="form-check-label" for="include_db_evidence">Include database evidence</label>
+                    </div>
                 </div>
-            </div>
             {% endif %}
 
             <!-- Include the network visualization partial template -->
-            {% if prefix in ['pubmed', 'pmc', 'doi'] %}
+            {% if prefix in ['pubmed', 'pmc', 'doi', 'go', 'subnetwork'] %}
                 {% include 'data_display/_network_visualization.html' %}
             {% endif %}
 
@@ -164,461 +164,514 @@
     </script>
 
     <!-- Network visualization for Publication Explorer -->
-    {% if prefix in ['pubmed', 'pmid', 'pmc', 'doi'] and stmts|length > 0 %}
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis-network.min.js"></script>
+    {% if prefix in ['pubmed', 'pmid', 'pmc', 'doi', 'go', 'subnetwork'] and stmts|length > 0 %}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis-network.min.js"></script>
 
-<style>
-/* Details dialog for edges and nodes */
-.details-dialog {
-    position: absolute;
-    background: white;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    padding: 15px;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.2);
-    z-index: 1000;
-    min-width: 300px;
-    max-width: 400px;
-}
-
-.details-dialog .close-btn {
-    position: absolute;
-    right: 10px;
-    top: 10px;
-    cursor: pointer;
-    font-size: 18px;
-    color: #999;
-}
-
-.details-dialog h3 {
-    margin-top: 0;
-    border-bottom: 1px solid #eee;
-    padding-bottom: 10px;
-    margin-bottom: 10px;
-}
-
-.details-dialog dl {
-    margin: 0;
-}
-
-.details-dialog dt {
-    font-weight: bold;
-    margin-top: 8px;
-}
-
-.details-dialog dd {
-    margin-left: 0;
-    margin-bottom: 5px;
-}
-
-.details-dialog a {
-    color: blue;
-    text-decoration: none;
-}
-
-.details-dialog a:hover {
-    text-decoration: underline;
-}
-</style>
-
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    // Get the paper ID from the identifier variable
-    const prefix = '{{ prefix }}';
-    const identifier = '{{ identifier }}';
-
-    console.log("Document loaded. Prefix:", prefix, "Identifier:", identifier);
-
-    initializeNetwork(prefix, identifier);
-
-    // Toggle network visibility
-    const toggleBtn = document.getElementById('toggle-network');
-    if (toggleBtn) {
-        toggleBtn.addEventListener('click', function() {
-            const container = document.getElementById('network-container');
-            if (container.style.display === 'none') {
-                container.style.display = 'block';
-                this.textContent = 'Hide Network';
-            } else {
-                container.style.display = 'none';
-                this.textContent = 'Show Network';
-            }
-        });
+    <style>
+    /* Details dialog for edges and nodes */
+    .details-dialog {
+        position: absolute;
+        background: white;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        padding: 15px;
+        box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+        z-index: 1000;
+        min-width: 300px;
+        max-width: 400px;
     }
 
-    // Reset button functionality
-    const resetBtn = document.getElementById('reset-network');
-    if (resetBtn) {
-        resetBtn.addEventListener('click', function() {
-            if (window.networkInstance) {
-                window.networkInstance.fit({
+    .details-dialog .close-btn {
+        position: absolute;
+        right: 10px;
+        top: 10px;
+        cursor: pointer;
+        font-size: 18px;
+        color: #999;
+    }
+
+    .details-dialog h3 {
+        margin-top: 0;
+        border-bottom: 1px solid #eee;
+        padding-bottom: 10px;
+        margin-bottom: 10px;
+    }
+
+    .details-dialog dl {
+        margin: 0;
+    }
+
+    .details-dialog dt {
+        font-weight: bold;
+        margin-top: 8px;
+    }
+
+    .details-dialog dd {
+        margin-left: 0;
+        margin-bottom: 5px;
+    }
+
+    .details-dialog a {
+        color: blue;
+        text-decoration: none;
+    }
+
+    .details-dialog a:hover {
+        text-decoration: underline;
+    }
+    </style>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        // Get the paper ID from the identifier variable
+        const prefix = '{{ prefix }}';
+        const identifier = '{{ identifier }}';
+
+        console.log("Document loaded. Prefix:", prefix, "Identifier:", identifier);
+
+        initializeNetwork(prefix, identifier);
+
+        // Toggle network visibility
+        const toggleBtn = document.getElementById('toggle-network');
+        if (toggleBtn) {
+            toggleBtn.addEventListener('click', function() {
+                const container = document.getElementById('network-container');
+                if (container.style.display === 'none') {
+                    container.style.display = 'block';
+                    this.textContent = 'Hide Network';
+                } else {
+                    container.style.display = 'none';
+                    this.textContent = 'Show Network';
+                }
+            });
+        }
+
+        // Reset button functionality
+        const resetBtn = document.getElementById('reset-network');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', function() {
+                if (window.networkInstance) {
+                    window.networkInstance.fit({
+                        animation: {
+                            duration: 1000,
+                            easingFunction: 'easeInOutQuad'
+                        }
+                    });
+                }
+            });
+        }
+    });
+
+    function initializeNetwork(prefix, identifier) {
+        console.log("initializeNetwork called with:", prefix, identifier);
+
+        const container = document.getElementById('network-container');
+        if (!container) {
+            console.error("Network container not found!");
+            return;
+        }
+
+        // Show loading indicator
+        container.innerHTML = '<div class="d-flex justify-content-center align-items-center" style="height: 100%;">' +
+                             '<div class="spinner-border text-primary" role="status"></div>' +
+                             '<span class="ml-2">Loading network...</span>' +
+                             '</div>';
+
+        // Get the current include_db_evidence value from Vue
+        const includeDbEvidence = app.include_db_evidence;
+        console.log("include_db_evidence:", includeDbEvidence);
+
+        // Determine which API to use based on prefix
+        let fetchUrl, payload;
+
+        if (prefix === 'go') {
+            fetchUrl = '/api/get_network_for_go_term';
+            payload = {
+                go_term: identifier,
+                include_db_evidence: includeDbEvidence,
+                limit: 25
+            };
+            console.log("Using GO term endpoint with payload:", payload);
+        }
+        else if (prefix === 'subnetwork') {
+            fetchUrl = '/api/get_network_for_subnetwork';
+            const nodes = identifier.split(',').map(item => {
+                const [ns, id] = item.split(':');
+                return [ns, id];
+            });
+            payload = {
+                nodes: nodes,
+                include_db_evidence: includeDbEvidence,
+                limit: 25
+            };
+            console.log("Using subnetwork endpoint with payload:", payload);
+        }
+        else {
+            fetchUrl = '/api/get_network_for_paper';
+            payload = {
+                paper_term: [prefix, identifier],
+                include_db_evidence: includeDbEvidence,
+                limit: 25
+            };
+            console.log("Using paper endpoint with payload:", payload);
+        }
+
+        // Call the API to get network data
+        fetch(fetchUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload)
+        })
+        .then(response => {
+            console.log("API response status:", response.status);
+            if (!response.ok) {
+                throw new Error(`API returned status ${response.status}`);
+            }
+            return response.json();
+        })
+        .then(data => {
+            console.log("API data received:", data);
+
+            if (!data.nodes || data.nodes.length === 0) {
+                let noDataMessage = 'No network data available';
+                if (prefix === 'go') {
+                    noDataMessage += ' for this GO term.';
+                } else if (prefix === 'subnetwork') {
+                    noDataMessage += ' for this subnetwork.';
+                } else {
+                    noDataMessage += ' for this paper.';
+                }
+                container.innerHTML = `<div class="alert alert-info">${noDataMessage}</div>`;
+                return;
+            }
+
+            console.log("Creating network with nodes:", data.nodes.length, "edges:", data.edges.length);
+
+            // Create the network
+            const nodes = new vis.DataSet(data.nodes);
+            const edges = new vis.DataSet(data.edges);
+
+            const networkData = {
+                nodes: nodes,
+                edges: edges
+            };
+
+            const options = {
+                nodes: {
+                    shape: 'ellipse',  // Default shape, overridden by individual settings
+                    size: 60,          // Large nodes
+                    font: {
+                        color: '#000000',
+                        size: 26,      // Larger font size (26)
+                        face: 'arial',
+                        vadjust: -40,  // Position labels further from nodes (-40)
+                        bold: true     // Make text bold for better visibility
+                    },
+                    borderWidth: 3,
+                    shadow: true
+                },
+                edges: {
+                    arrows: {
+                        to: { enabled: true, scaleFactor: 0.5 }
+                    },
+                    font: {
+                        size: 0,       // Hide edge labels (will show in dialog instead)
+                        align: 'middle',
+                        color: '#333333',
+                        strokeWidth: 0
+                    },
+                    width: 5,          // Thick edges
+                    smooth: {
+                        enabled: true,
+                        type: 'dynamic'
+                    },
+                    shadow: true
+                },
+                physics: {
+                    enabled: true,
+                    barnesHut: {
+                        gravitationalConstant: -8000,
+                        centralGravity: 0.05,
+                        springLength: 350,
+                        springConstant: 0.03
+                    },
+                    stabilization: {
+                        enabled: true,
+                        iterations: 2000
+                    }
+                },
+                interaction: {
+                    hover: true,
+                    tooltipDelay: 200,
+                    zoomView: true,
+                    dragView: true,
+                    selectable: true,
+                    selectConnectedEdges: true,
+                    hoverConnectedEdges: true
+                },
+                layout: {
+                    improvedLayout: true,
+                }
+            };
+
+            // Initialize the network
+            const network = new vis.Network(container, networkData, options);
+
+            // Force a more spread out layout
+            network.setOptions({
+               physics: {
+                   enabled: true,
+                   stabilization: {
+                       enabled: true,
+                       iterations: 2000
+                   }
+               }
+            });
+
+            // Start over with stabilization
+            network.stabilize(2000);
+
+            // Store network instance globally for access by reset button
+            window.networkInstance = network;
+
+            // Start with a zoomed out view to see the whole network
+            network.once('stabilizationIterationsDone', function() {
+                // Instead of fitting, set a specific zoom level
+                network.moveTo({
+                    scale: 0.75,  // Zoom out to 75%
                     animation: {
                         duration: 1000,
                         easingFunction: 'easeInOutQuad'
                     }
                 });
-            }
-        });
-    }
-});
-
-function initializeNetwork(prefix, identifier) {
-    console.log("initializeNetwork called with:", prefix, identifier);
-
-    const container = document.getElementById('network-container');
-    if (!container) {
-        console.error("Network container not found!");
-        return;
-    }
-
-    // Show loading indicator
-    container.innerHTML = '<div class="d-flex justify-content-center align-items-center" style="height: 100%;">' +
-                         '<div class="spinner-border text-primary" role="status"></div>' +
-                         '<span class="ml-2">Loading network...</span>' +
-                         '</div>';
-
-    // Get the current include_db_evidence value from Vue
-    const includeDbEvidence = app.include_db_evidence;
-    console.log("include_db_evidence:", includeDbEvidence);
-
-    // Call the API to get network data
-    fetch(`/api/get_network_for_paper`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-            paper_term: [prefix, identifier],
-            include_db_evidence: includeDbEvidence,
-            limit: 25
-        })
-    })
-    .then(response => {
-        console.log("API response status:", response.status);
-        if (!response.ok) {
-            throw new Error(`API returned status ${response.status}`);
-        }
-        return response.json();
-    })
-    .then(data => {
-        console.log("API data received:", data);
-
-        if (!data.nodes || data.nodes.length === 0) {
-            container.innerHTML = '<div class="alert alert-info">No network data available for this paper.</div>';
-            return;
-        }
-
-        console.log("Creating network with nodes:", data.nodes.length, "edges:", data.edges.length);
-
-        // Create the network
-        const nodes = new vis.DataSet(data.nodes);
-        const edges = new vis.DataSet(data.edges);
-
-        const networkData = {
-            nodes: nodes,
-            edges: edges
-        };
-
-        const options = {
-            nodes: {
-                shape: 'ellipse',  // Default shape, overridden by individual settings
-                size: 60,          // Large nodes
-                font: {
-                    color: '#000000',
-                    size: 26,      // Larger font size (26)
-                    face: 'arial',
-                    vadjust: -40,  // Position labels further from nodes (-40)
-                    bold: true     // Make text bold for better visibility
-                },
-                borderWidth: 3,
-                shadow: true
-            },
-            edges: {
-                arrows: {
-                    to: { enabled: true, scaleFactor: 0.5 }
-                },
-                font: {
-                    size: 0,       // Hide edge labels (will show in dialog instead)
-                    align: 'middle',
-                    color: '#333333',
-                    strokeWidth: 0
-                },
-                width: 5,          // Thick edges
-                smooth: {
-                    enabled: true,
-                    type: 'dynamic'
-                },
-                shadow: true
-            },
-            physics: {
-                enabled: true,
-                barnesHut: {
-                    gravitationalConstant: -2000,
-                    centralGravity: 0.1,
-                    springLength: 200,
-                    springConstant: 0.04
-                },
-                stabilization: {
-                    enabled: true,
-                    iterations: 1000
-                }
-            },
-            interaction: {
-                hover: true,
-                tooltipDelay: 200,
-                zoomView: true,
-                dragView: true,
-                selectable: true,
-                selectConnectedEdges: true,
-                hoverConnectedEdges: true
-            },
-            layout: {
-                improvedLayout: true,
-            }
-        };
-
-        // Initialize the network
-        const network = new vis.Network(container, networkData, options);
-
-        // Store network instance globally for access by reset button
-        window.networkInstance = network;
-
-        // Start with a zoomed out view to see the whole network
-        network.once('stabilizationIterationsDone', function() {
-            // Instead of fitting, set a specific zoom level
-            network.moveTo({
-                scale: 0.75,  // Zoom out to 75%
-                animation: {
-                    duration: 1000,
-                    easingFunction: 'easeInOutQuad'
-                }
             });
-        });
 
-        // Create and manage the details dialog
-        let detailsDialog = null;
+            // Create and manage the details dialog
+            let detailsDialog = null;
 
-        function showEdgeDetails(edge) {
-            // Remove any existing dialog
-            if (detailsDialog) {
-                document.body.removeChild(detailsDialog);
-            }
+            function showEdgeDetails(edge) {
+                // Remove any existing dialog
+                if (detailsDialog) {
+                    document.body.removeChild(detailsDialog);
+                }
 
-            // Create new dialog
-            detailsDialog = document.createElement('div');
-            detailsDialog.className = 'details-dialog';
+                // Create new dialog
+                detailsDialog = document.createElement('div');
+                detailsDialog.className = 'details-dialog';
 
-            // Get edge data
-            const edgeData = edges.get(edge.edgeId);
-            const details = edgeData.details || {};
+                // Get edge data
+                const edgeData = edges.get(edge.edgeId);
+                const details = edgeData.details || {};
 
-            // Format belief score to 2 decimal places
-            const beliefScore = typeof details.belief === 'number' ? details.belief.toFixed(2) : 'N/A';
+                // Format belief score to 2 decimal places
+                const beliefScore = typeof details.belief === 'number' ? details.belief.toFixed(2) : 'N/A';
 
-            // Build dialog content
-            detailsDialog.innerHTML = `
-                <span class="close-btn">×</span>
-                <h3>Edge Details</h3>
-                <dl>
-                    <dt>belief</dt>
-                    <dd>${beliefScore}</dd>
+                // Build dialog content
+                detailsDialog.innerHTML = `
+                    <span class="close-btn">×</span>
+                    <h3>Edge Details</h3>
+                    <dl>
+                        <dt>belief</dt>
+                        <dd>${beliefScore}</dd>
 
-                    <dt>INDRA statement</dt>
-                    <dd>${details.indra_statement || 'Unknown'}</dd>
+                        <dt>INDRA statement</dt>
+                        <dd>${details.indra_statement || 'Unknown'}</dd>
 
-                    <dt>interaction</dt>
-                    <dd>${details.interaction || 'Unknown'}</dd>
+                        <dt>interaction</dt>
+                        <dd>${details.interaction || 'Unknown'}</dd>
 
-                    <dt>polarity</dt>
-                    <dd>${details.polarity || 'none'}</dd>
+                        <dt>polarity</dt>
+                        <dd>${details.polarity || 'none'}</dd>
 
-                    <dt>supportType</dt>
-                    <dd>${details.support_type || 'Unknown'}</dd>
+                        <dt>supportType</dt>
+                        <dd>${details.support_type || 'Unknown'}</dd>
 
-                    <dt>type</dt>
-                    <dd>${details.type || 'Unknown'}</dd>
-                </dl>
-            `;
-
-            // Position dialog near click
-            const pos = network.getPositions([edgeData.from, edgeData.to]);
-            const fromPos = pos[edgeData.from];
-            const toPos = pos[edgeData.to];
-
-            // Get middle point of edge
-            const x = (fromPos.x + toPos.x) / 2;
-            const y = (fromPos.y + toPos.y) / 2;
-
-            // Convert to DOM coordinates
-            const domPos = network.canvasToDOM({x: x, y: y});
-
-            // Position dialog
-            detailsDialog.style.left = `${domPos.x + 20}px`;
-            detailsDialog.style.top = `${domPos.y + 20}px`;
-
-            // Add to DOM
-            document.body.appendChild(detailsDialog);
-
-            // Add close handler
-            const closeBtn = detailsDialog.querySelector('.close-btn');
-            closeBtn.addEventListener('click', function() {
-                document.body.removeChild(detailsDialog);
-                detailsDialog = null;
-            });
-        }
-
-        function showNodeDetails(node) {
-            // Remove any existing dialog
-            if (detailsDialog) {
-                document.body.removeChild(detailsDialog);
-            }
-
-            // Create new dialog
-            detailsDialog = document.createElement('div');
-            detailsDialog.className = 'details-dialog';
-
-            // Get node data
-            const nodeData = nodes.get(node.nodeId);
-            const details = nodeData.details || {};
-
-            // Format node information for dialog
-            let dialogContent = `
-                <span class="close-btn">×</span>
-                <h3>${nodeData.label}</h3>
-                <dl>
-            `;
-
-            // Add EGID if available
-            if (nodeData.egid) {
-                dialogContent += `
-                    <dt>EGID</dt>
-                    <dd><a href="https://bioregistry.io/ncbigene:${nodeData.egid}" target="_blank">https://bioregistry.io/ncbigene:${nodeData.egid}</a></dd>
+                        <dt>type</dt>
+                        <dd>${details.type || 'Unknown'}</dd>
+                    </dl>
                 `;
+
+                // Position dialog near click
+                const pos = network.getPositions([edgeData.from, edgeData.to]);
+                const fromPos = pos[edgeData.from];
+                const toPos = pos[edgeData.to];
+
+                // Get middle point of edge
+                const x = (fromPos.x + toPos.x) / 2;
+                const y = (fromPos.y + toPos.y) / 2;
+
+                // Convert to DOM coordinates
+                const domPos = network.canvasToDOM({x: x, y: y});
+
+                // Position dialog
+                detailsDialog.style.left = `${domPos.x + 20}px`;
+                detailsDialog.style.top = `${domPos.y + 20}px`;
+
+                // Add to DOM
+                document.body.appendChild(detailsDialog);
+
+                // Add close handler
+                const closeBtn = detailsDialog.querySelector('.close-btn');
+                closeBtn.addEventListener('click', function() {
+                    document.body.removeChild(detailsDialog);
+                    detailsDialog = null;
+                });
             }
 
-            // Add HGNC if available
-            if (nodeData.hgnc) {
-                dialogContent += `
-                    <dt>HGNC</dt>
-                    <dd><a href="https://bioregistry.io/hgnc:${nodeData.hgnc}" target="_blank">https://bioregistry.io/hgnc:${nodeData.hgnc}</a></dd>
+            function showNodeDetails(node) {
+                // Remove any existing dialog
+                if (detailsDialog) {
+                    document.body.removeChild(detailsDialog);
+                }
+
+                // Create new dialog
+                detailsDialog = document.createElement('div');
+                detailsDialog.className = 'details-dialog';
+
+                // Get node data
+                const nodeData = nodes.get(node.nodeId);
+                const details = nodeData.details || {};
+
+                // Format node information for dialog
+                let dialogContent = `
+                    <span class="close-btn">×</span>
+                    <h3>${nodeData.label}</h3>
+                    <dl>
                 `;
-            }
 
-            // Add type
-            dialogContent += `
-                <dt>type</dt>
-                <dd>${nodeData.type || 'Unknown'}</dd>
-            `;
-
-            // Add UniProt if available
-            if (nodeData.uniprot) {
-                dialogContent += `
-                    <dt>UniProt</dt>
-                    <dd><a href="https://bioregistry.io/uniprot:${nodeData.uniprot}" target="_blank">https://bioregistry.io/uniprot:${nodeData.uniprot}</a></dd>
-                `;
-            }
-
-            // Add any other database references
-            if (details) {
-                for (const [key, value] of Object.entries(details)) {
-                    // Skip ones we've already added
-                    if (['EGID', 'HGNC', 'UP'].includes(key)) continue;
-
+                // Add EGID if available
+                if (nodeData.egid) {
                     dialogContent += `
-                        <dt>${key}</dt>
-                        <dd>${value}</dd>
+                        <dt>EGID</dt>
+                        <dd><a href="https://identifiers.org/ncbigene:${nodeData.egid}" target="_blank">https://identifiers.org/ncbigene:${nodeData.egid}</a></dd>
                     `;
                 }
+
+                // Add HGNC if available
+                if (nodeData.hgnc) {
+                    dialogContent += `
+                        <dt>HGNC</dt>
+                        <dd><a href="https://identifiers.org/hgnc:${nodeData.hgnc}" target="_blank">https://identifiers.org/hgnc:${nodeData.hgnc}</a></dd>
+                    `;
+                }
+
+                // Add type
+                dialogContent += `
+                    <dt>type</dt>
+                    <dd>${nodeData.type || 'Unknown'}</dd>
+                `;
+
+                // Add UniProt if available
+                if (nodeData.uniprot) {
+                    dialogContent += `
+                        <dt>UniProt</dt>
+                        <dd><a href="https://identifiers.org/uniprot:${nodeData.uniprot}" target="_blank">https://identifiers.org/uniprot:${nodeData.uniprot}</a></dd>
+                    `;
+                }
+
+                // Add any other database references
+                if (details) {
+                    for (const [key, value] of Object.entries(details)) {
+                        // Skip ones we've already added
+                        if (['EGID', 'HGNC', 'UP'].includes(key)) continue;
+
+                        dialogContent += `
+                            <dt>${key}</dt>
+                            <dd>${value}</dd>
+                        `;
+                    }
+                }
+
+                dialogContent += `</dl>`;
+                detailsDialog.innerHTML = dialogContent;
+
+                // Position dialog near clicked node
+                const pos = network.getPositions([node.nodeId])[node.nodeId];
+                const domPos = network.canvasToDOM(pos);
+
+                // Position dialog
+                detailsDialog.style.left = `${domPos.x + 30}px`;
+                detailsDialog.style.top = `${domPos.y - 30}px`;
+
+                // Add to DOM
+                document.body.appendChild(detailsDialog);
+
+                // Add close handler
+                const closeBtn = detailsDialog.querySelector('.close-btn');
+                closeBtn.addEventListener('click', function() {
+                    document.body.removeChild(detailsDialog);
+                    detailsDialog = null;
+                });
             }
 
-            dialogContent += `</dl>`;
-            detailsDialog.innerHTML = dialogContent;
-
-            // Position dialog near clicked node
-            const pos = network.getPositions([node.nodeId])[node.nodeId];
-            const domPos = network.canvasToDOM(pos);
-
-            // Position dialog
-            detailsDialog.style.left = `${domPos.x + 30}px`;
-            detailsDialog.style.top = `${domPos.y - 30}px`;
-
-            // Add to DOM
-            document.body.appendChild(detailsDialog);
-
-            // Add close handler
-            const closeBtn = detailsDialog.querySelector('.close-btn');
-            closeBtn.addEventListener('click', function() {
-                document.body.removeChild(detailsDialog);
-                detailsDialog = null;
+            // Handle clicks - Check nodes FIRST, then edges
+            network.on("click", function(params) {
+                // If a node was clicked
+                if (params.nodes && params.nodes.length > 0) {
+                    showNodeDetails({
+                        nodeId: params.nodes[0]
+                    });
+                }
+                // If an edge was clicked
+                else if (params.edges && params.edges.length > 0) {
+                    showEdgeDetails({
+                        edgeId: params.edges[0]
+                    });
+                }
+                // If clicking elsewhere, close dialog
+                else if (detailsDialog && !params.event.srcElement.closest('.details-dialog')) {
+                    document.body.removeChild(detailsDialog);
+                    detailsDialog = null;
+                }
             });
-        }
 
-        // Handle clicks - Check nodes FIRST, then edges
-        network.on("click", function(params) {
-            // If a node was clicked
-            if (params.nodes && params.nodes.length > 0) {
-                showNodeDetails({
-                    nodeId: params.nodes[0]
-                });
-            }
-            // If an edge was clicked
-            else if (params.edges && params.edges.length > 0) {
-                showEdgeDetails({
-                    edgeId: params.edges[0]
-                });
-            }
-            // If clicking elsewhere, close dialog
-            else if (detailsDialog && !params.event.srcElement.closest('.details-dialog')) {
-                document.body.removeChild(detailsDialog);
-                detailsDialog = null;
-            }
+            // Double-click to highlight connections
+            network.on("doubleClick", function(params) {
+                if (params.nodes.length > 0) {
+                    const nodeId = params.nodes[0];
+                    const connectedNodes = network.getConnectedNodes(nodeId);
+                    const connectedEdges = network.getConnectedEdges(nodeId);
+
+                    // Highlight the selected node and its connections
+                    nodes.get().forEach(node => {
+                        if (node.id === nodeId) {
+                            nodes.update({id: node.id, borderWidth: 4, color: {border: '#FF5722'}});
+                        } else if (connectedNodes.includes(node.id)) {
+                            nodes.update({id: node.id, borderWidth: 3, color: {border: '#FF9800'}});
+                        } else {
+                            nodes.update({id: node.id, opacity: 0.3});
+                        }
+                    });
+
+                    // Highlight connected edges
+                    edges.get().forEach(edge => {
+                        if (connectedEdges.includes(edge.id)) {
+                            edges.update({id: edge.id, width: edge.width * 1.5});
+                        } else {
+                            edges.update({id: edge.id, opacity: 0.1});
+                        }
+                    });
+                } else {
+                    // Reset all highlights
+                    nodes.get().forEach(node => {
+                        nodes.update({id: node.id, borderWidth: 2, opacity: 1.0, color: {border: '#37474F'}});
+                    });
+
+                    edges.get().forEach(edge => {
+                        const originalWidth = edge.width / 1.5;
+                        edges.update({id: edge.id, width: originalWidth, opacity: 1.0});
+                    });
+                }
+            });
+        })
+        .catch(error => {
+            console.error('Error fetching network data:', error);
+            container.innerHTML = '<div class="alert alert-danger">Error loading network visualization. Please try again later.</div>';
         });
-
-        // Double-click to highlight connections
-        network.on("doubleClick", function(params) {
-            if (params.nodes.length > 0) {
-                const nodeId = params.nodes[0];
-                const connectedNodes = network.getConnectedNodes(nodeId);
-                const connectedEdges = network.getConnectedEdges(nodeId);
-
-                // Highlight the selected node and its connections
-                nodes.get().forEach(node => {
-                    if (node.id === nodeId) {
-                        nodes.update({id: node.id, borderWidth: 4, color: {border: '#FF5722'}});
-                    } else if (connectedNodes.includes(node.id)) {
-                        nodes.update({id: node.id, borderWidth: 3, color: {border: '#FF9800'}});
-                    } else {
-                        nodes.update({id: node.id, opacity: 0.3});
-                    }
-                });
-
-                // Highlight connected edges
-                edges.get().forEach(edge => {
-                    if (connectedEdges.includes(edge.id)) {
-                        edges.update({id: edge.id, width: edge.width * 1.5});
-                    } else {
-                        edges.update({id: edge.id, opacity: 0.1});
-                    }
-                });
-            } else {
-                // Reset all highlights
-                nodes.get().forEach(node => {
-                    nodes.update({id: node.id, borderWidth: 2, opacity: 1.0, color: {border: '#37474F'}});
-                });
-
-                edges.get().forEach(edge => {
-                    const originalWidth = edge.width / 1.5;
-                    edges.update({id: edge.id, width: originalWidth, opacity: 1.0});
-                });
-            }
-        });
-    })
-    .catch(error => {
-        console.error('Error fetching network data:', error);
-        container.innerHTML = '<div class="alert alert-danger">Error loading network visualization. Please try again later.</div>';
-    });
-}
-</script>
-{% endif %}
+    }
+    </script>
+    {% endif %}
 {% endblock %}

--- a/src/indra_cogex/apps/templates/data_display/data_display_base.html
+++ b/src/indra_cogex/apps/templates/data_display/data_display_base.html
@@ -283,38 +283,39 @@
         console.log("include_db_evidence:", includeDbEvidence);
 
         // Determine which API to use based on prefix
-        let fetchUrl, payload;
+        let fetchUrl = '/api/get_network';
+        let payload;
 
         if (prefix === 'go') {
-            fetchUrl = '/api/get_network_for_go_term';
             payload = {
-                go_term: identifier,
+                network_type: 'go',
+                identifier: identifier,
                 include_db_evidence: includeDbEvidence,
                 limit: 25
             };
-            console.log("Using GO term endpoint with payload:", payload);
+            console.log("Using GO term with unified endpoint:", payload);
         }
         else if (prefix === 'subnetwork') {
-            fetchUrl = '/api/get_network_for_subnetwork';
             const nodes = identifier.split(',').map(item => {
                 const [ns, id] = item.split(':');
                 return [ns, id];
             });
             payload = {
-                nodes: nodes,
+                network_type: 'subnetwork',
+                identifier: nodes,
                 include_db_evidence: includeDbEvidence,
                 limit: 25
             };
-            console.log("Using subnetwork endpoint with payload:", payload);
+            console.log("Using subnetwork with unified endpoint:", payload);
         }
         else {
-            fetchUrl = '/api/get_network_for_paper';
             payload = {
-                paper_term: [prefix, identifier],
+                network_type: 'paper',
+                identifier: [prefix, identifier],
                 include_db_evidence: includeDbEvidence,
                 limit: 25
             };
-            console.log("Using paper endpoint with payload:", payload);
+            console.log("Using paper with unified endpoint:", payload);
         }
 
         // Call the API to get network data
@@ -393,14 +394,14 @@
                 physics: {
                     enabled: true,
                     barnesHut: {
-                        gravitationalConstant: -8000,
-                        centralGravity: 0.05,
-                        springLength: 350,
-                        springConstant: 0.03
+                        gravitationalConstant: -8000,  // Much stronger repulsion (was -2000)
+                        centralGravity: 0.05,          // Less pull to center (was 0.1)
+                        springLength: 350,             // Much longer springs (was 200)
+                        springConstant: 0.03           // Slightly looser springs (was 0.04)
                     },
                     stabilization: {
                         enabled: true,
-                        iterations: 2000
+                        iterations: 2000               // More iterations for better layout
                     }
                 },
                 interaction: {
@@ -420,28 +421,28 @@
             // Initialize the network
             const network = new vis.Network(container, networkData, options);
 
+            // Store network instance globally for access by reset button
+            window.networkInstance = network;
+
             // Force a more spread out layout
             network.setOptions({
-               physics: {
-                   enabled: true,
-                   stabilization: {
-                       enabled: true,
-                       iterations: 2000
-                   }
-               }
+                physics: {
+                    enabled: true,
+                    stabilization: {
+                        enabled: true,
+                        iterations: 2000
+                    }
+                }
             });
 
             // Start over with stabilization
             network.stabilize(2000);
 
-            // Store network instance globally for access by reset button
-            window.networkInstance = network;
-
             // Start with a zoomed out view to see the whole network
             network.once('stabilizationIterationsDone', function() {
                 // Instead of fitting, set a specific zoom level
                 network.moveTo({
-                    scale: 0.75,  // Zoom out to 75%
+                    scale: 0.65,  // Zoom out more (was 0.75)
                     animation: {
                         duration: 1000,
                         easingFunction: 'easeInOutQuad'


### PR DESCRIPTION
This PR introduces new API endpoints and frontend integration to support dynamic vis.js network graph visualizations for:

GO Explorer (/api/get_network_for_go_term)
Subnetwork Explorer (/api/get_network_for_subnetwork)

Key changes include:

Implemented new backend endpoints with @autoclient decorators using INDRA statements via indra_subnetwork_go and indra_subnetwork.

Created corresponding integration tests to validate network structure and belief-based edges.

Updated data_display_base.html and JS logic to dynamically detect the explorer type (prefix) and render the correct network using vis.js.

Extended HTML templates and conditional checks to support GO and Subnetwork graph inclusion.

These additions bring GO and Subnetwork pages to feature parity with the Publication Explorer, enabling interactive network visualizations with metadata-rich tooltips and connectivity highlighting.