### PR TITLE
Fix search grounding check

### DIFF
--- a/src/indra_cogex/apps/search/search.py
+++ b/src/indra_cogex/apps/search/search.py
@@ -55,9 +55,13 @@ def search():
     # POST Request: Generate a sharable link with query parameters
     if request.method == 'POST':
         agent = form.agent_name.data
+        agent_tuple = json.loads(request.form.get("agent_tuple") or "null")
 
         if agent:
-            agent, is_curie = check_and_convert(agent)
+            if agent_tuple:
+                agent, is_curie = check_and_convert(":".join(agent_tuple))
+            else:
+                is_curie = False
             agent_exists = check_agent_existence(agent)
 
             if agent_exists is False:
@@ -74,7 +78,8 @@ def search():
                 )
         query_params = {
             "agent": form.agent_name.data,
-            "agent_tuple": request.form.get("agent_tuple"),
+            # JSON dumps for proper encoding
+            "agent_tuple": json.dumps(agent_tuple) if agent_tuple else None,
             "other_agent": form.other_agent.data,
             "other_agent_tuple": request.form.get("other_agent_tuple"),
             "source_type": form.source_type.data,

--- a/src/indra_cogex/apps/search/search.py
+++ b/src/indra_cogex/apps/search/search.py
@@ -64,7 +64,7 @@ def search():
                 is_curie = False
             agent_exists = check_agent_existence(agent)
 
-            if agent_exists is False:
+            if not agent_exists:
                 if is_curie:
                     error_agent = f'{agent[0]}:{agent[1]}'
                 else:
@@ -96,7 +96,7 @@ def search():
     # GET Request: Extract query parameters and fetch statements
     agent = request.args.get("agent")
 
-    #Check if the agent is in CURIE form
+    # Check if the agent is in CURIE form
     if agent:
         agent, _ = check_and_convert(agent)
 

--- a/src/indra_cogex/apps/templates/search/search_page.html
+++ b/src/indra_cogex/apps/templates/search/search_page.html
@@ -200,8 +200,8 @@
 
     <form method="POST" id="agent-form">
         <div class="form-group">
-            <label for="clickable-text" class="form-label">Example Usages:</label>
-            <ul style="padding-left: 20px;">
+            <label for="clickable-text-list" class="form-label">Example Usages:</label>
+            <ul id="clickable-text-list" style="padding-left: 20px;">
                 <li>
                     <p id="clickable-text-example1" class="clickable-text" style="cursor: pointer; color: blue; text-decoration: underline; display: inline;">
                         How does DUSP1 affect MAPK1?

--- a/src/indra_cogex/apps/templates/search/search_page.html
+++ b/src/indra_cogex/apps/templates/search/search_page.html
@@ -291,7 +291,7 @@
             <label for="other-agent-name" id="other-agent-label" class="tooltip-label">
                 <span id="other-agent-text">Other Agent</span>
                 <div class="other-agent-tooltip-box">
-                    (Optional): Promped when the agent role is selected.
+                    (Optional): Prompted when the agent role is selected.
                 </div>
                 <span class="orange-dot" style="margin-left: 3px;"></span>
             </label>


### PR DESCRIPTION
This PR resolves an issue where if a name was provided for grounding that was not the preferred standard name, the form submission would error, because the grounding was not taken into account on the back end when checking for the existence of the provided agent.

Update not related to the fix:
Fix id and code formatting in the jinja template