### PR TITLE
Dockerfile fix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,7 +64,7 @@ RUN git clone https://github.com/sorgerlab/indra.git && \
     # Download protmapper resources
     python -m protmapper.resources && \
     # Download gilda resources
-    RUN python -m gilda.resources && \
+    python -m gilda.resources && \
     # Install BioNetGen
     cd $DIRPATH && \
     wget "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.4.0/BioNetGen-2.4.0-Linux.tgz" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,6 +61,8 @@ RUN git clone https://github.com/sorgerlab/indra.git && \
     python -m adeft.download && \
     # Download protmapper resources
     python -m protmapper.resources && \
+    # Download gilda resources
+    RUN python -m gilda.resources && \
     # Install BioNetGen
     cd $DIRPATH && \
     wget "https://github.com/RuleWorld/bionetgen/releases/download/BioNetGen-2.4.0/BioNetGen-2.4.0-Linux.tgz" \
@@ -77,9 +79,6 @@ RUN python -m indra_cogex.client.enrichment.utils --force
 
 # Save agent name in cache for search
 RUN python -m indra_cogex.apps.search.utils --cache
-
-# Run the gilda resource file download so it doesn't happen at runtime
-RUN python -m gilda.resources
 
 ENV GUNICORN_CONF /usr/local/lib/python3.8/dist-packages/indra_cogex/apps/gunicorn.conf.py
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,7 @@ RUN git clone https://github.com/sorgerlab/indra.git && \
     pip install --upgrade pip && \
     # Install cython first for pyjnius
     pip install "cython<3" && \
+    pip install "pyjnius==1.1.4" && \
     pip install -e .[all] && \
     pip uninstall -y enum34 && \
     # Pre-build the bio ontology

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
     apt-get install -y openjdk-8-jdk && \
     # jnius-indra requires cython which requires gcc
     apt-get install -y git wget zip unzip bzip2 gcc graphviz graphviz-dev \
-        pkg-config python3-pip && \
+        pkg-config python3-pip cmake libxml2-dev swig && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 # Set default character encoding

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,6 +54,7 @@ RUN git clone https://github.com/sorgerlab/indra.git && \
     # Install cython first for pyjnius
     pip install "cython<3" && \
     pip install "pyjnius==1.1.4" && \
+    pip install --prefer-binary python-libsbml || true && \
     pip install -e .[all] && \
     pip uninstall -y enum34 && \
     # Pre-build the bio ontology

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN git clone https://github.com/sorgerlab/indra.git && \
     # Install Python dependencies
     pip install --upgrade pip && \
     # Install cython first for pyjnius
-    pip install cython && \
+    pip install "cython<3" && \
     pip install -e .[all] && \
     pip uninstall -y enum34 && \
     # Pre-build the bio ontology

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,6 +78,9 @@ RUN python -m indra_cogex.client.enrichment.utils --force
 # Save agent name in cache for search
 RUN python -m indra_cogex.apps.search.utils --cache
 
+# Run the gilda resource file download so it doesn't happen at runtime
+RUN python -m gilda.resources
+
 ENV GUNICORN_CONF /usr/local/lib/python3.8/dist-packages/indra_cogex/apps/gunicorn.conf.py
 
 ENTRYPOINT gunicorn -w 4 -c $GUNICORN_CONF -t 300 -b 0.0.0.0:5000 indra_cogex.apps.wsgi:app


### PR DESCRIPTION
This PR updates the Dockerfile, which recently (~past month) started to error on build due dependency creep. (It started with Cython not being able to be installed properly).

### Other changes:
- Added gilda resource download. Previously, the resource files would be downloaded on first call to grounding.

This doesn't fully solve #224, but rather patches the Dockerfile until we can do a larger update.
