### PR TITLE
Subnetwork fixes

### DIFF
--- a/src/indra_cogex/apps/queries_web/__init__.py
+++ b/src/indra_cogex/apps/queries_web/__init__.py
@@ -379,7 +379,10 @@ examples_dict = {
     "downstream_targets": fields.Boolean(example=False),
     "include_child_terms": fields.Boolean(example=True),
     "return_source_counts": fields.Boolean(example=False),
-    "order_by_ev_count": fields.Boolean(example=False),
+    "order_by_ev_count": {
+        "indra_mediated_subnetwork": fields.Boolean(example=True),
+        "default": fields.Boolean(example=False),
+    },
     # NOTE: statement hashes are too large to be int for JavaScript
     "stmt_hash": fields.String(example="12198579805553967"),
     "stmt_hashes": {
@@ -418,7 +421,7 @@ examples_dict = {
     "evidence_limit": fields.Integer(example=30),
     "nodes": fields.List(
         fields.List(fields.String),
-        example=[["FPLX", "MEK"], ["FPLX", "ERK"]]
+        example=[["HGNC", "10013"], ["HGNC", "10006"]]
     ),
     "offset": fields.Integer(example=1),
     # Analysis API

--- a/src/indra_cogex/apps/queries_web/__init__.py
+++ b/src/indra_cogex/apps/queries_web/__init__.py
@@ -6,7 +6,8 @@ The endpoints are created dynamically based on the functions in the following mo
 - indra_cogex.client.queries
 - indra_cogex.client.subnetwork
 - indra_cogex.analysis.metabolite_analysis
-- indra_cogex.analysis.gene_analysis
+- indra_cogex.analysis.gene_analysis,
+- indra_cogex.analysis.source_targets_explanation
 """
 import csv
 import logging
@@ -343,7 +344,10 @@ examples_dict = {
         "get_enzyme_activities_for_gene": fields.List(fields.String, example=["hgnc", "10007"]),
         "default": fields.List(fields.String, example=["HGNC", "9896"])
     },
-    "go_term": fields.List(fields.String, example=["GO", "GO:0000978"]),
+    "go_term": {
+        "indra_subnetwork_go": fields.List(fields.String, example=["GO", "GO:1900745"]),
+        "default": fields.List(fields.String, example=["GO", "GO:0000978"])
+    },
     "drug": {
         "get_sensitive_cell_lines_for_drug": fields.List(fields.String, example=["mesh", "C586365"]),
         "default": fields.List(fields.String, example=["CHEBI", "CHEBI:27690"])
@@ -379,10 +383,7 @@ examples_dict = {
     "downstream_targets": fields.Boolean(example=False),
     "include_child_terms": fields.Boolean(example=True),
     "return_source_counts": fields.Boolean(example=False),
-    "order_by_ev_count": {
-        "indra_mediated_subnetwork": fields.Boolean(example=True),
-        "default": fields.Boolean(example=False),
-    },
+    "order_by_ev_count": fields.Boolean(example=True),
     # NOTE: statement hashes are too large to be int for JavaScript
     "stmt_hash": fields.String(example="12198579805553967"),
     "stmt_hashes": {
@@ -419,10 +420,20 @@ examples_dict = {
     "filter_medscan": fields.Boolean(example=True),
     "limit": fields.Integer(example=30),
     "evidence_limit": fields.Integer(example=30),
-    "nodes": fields.List(
-        fields.List(fields.String),
-        example=[["HGNC", "10013"], ["HGNC", "10006"]]
-    ),
+    "nodes": {
+        "default": fields.List(
+            fields.List(fields.String),
+            example=[["HGNC", "10013"], ["FPLX", "GPCR"]]
+        ),
+        "indra_mediated_subnetwork": fields.List(
+            fields.List(fields.String),
+            example=[["HGNC", "10013"], ["HGNC", "10006"]]
+        ),
+        "indra_subnetwork_tissue": fields.List(
+            fields.List(fields.String),
+            example=[['HGNC', '12856'], ['HGNC', '1266'], ['HGNC', '30412']]
+        ),
+    },
     "offset": fields.Integer(example=1),
     # Analysis API
     # Metabolite analysis, and gene analysis examples (discrete, signed, continuous)

--- a/src/indra_cogex/client/subnetwork.py
+++ b/src/indra_cogex/client/subnetwork.py
@@ -326,8 +326,8 @@ def indra_subnetwork_tissue(
         The subnetwork induced by the given nodes and expressed in the given tissue.
     """
     genes = get_genes_in_tissue(client=client, tissue=tissue)
-    relevant_genes = {g.grounding() for g in genes} & set(nodes)
-    return indra_subnetwork(client, relevant_genes)
+    relevant_genes = {g.grounding() for g in genes} & {tuple(nc) for nc in nodes}
+    return indra_subnetwork(list(relevant_genes), client=client)
 
 
 @autoclient()


### PR DESCRIPTION
This PR updates `indra_subnetwork_tissue` to fix a bug in which under certain circumstances, it was possible that a list of lists instead of a list of tuples would be provided as nodes, which chokes the python `set` since you can't hash a list.

Other updates:
- Update examples for the apidocs for the subnetwork functions to something less costly as several of the examples would crash the apidocs UI due to too large results.
- Update the file docstring of `queries_web/__init__.py`