### PR TITLE
Add missing remove_medscan

### DIFF
--- a/src/indra_cogex/apps/data_display/__init__.py
+++ b/src/indra_cogex/apps/data_display/__init__.py
@@ -291,7 +291,10 @@ def get_evidence(stmt_hash):
 
         # Get the formatted evidence rows
         stmt_rows = format_stmts(
-            stmts=[stmt], evidence_counts=ev_counts, curations=curations
+            stmts=[stmt],
+            evidence_counts=ev_counts,
+            curations=curations,
+            remove_medscan=remove_medscan,
         )
 
         # Return the evidence json for the statement


### PR DESCRIPTION
This PR adds `remove_medscan` to the `format_stms` call in the `get_evidence` endpoint function. This resolves a corner case bug in which a statement with a single evidence from medscan was always filtered and `format_stms` returned an empty list, which created an error when trying to index into the empty list.