### PR TITLE
Incremental ingest via LOAD CSV

### DIFF
--- a/src/indra_cogex/client/neo4j_client.py
+++ b/src/indra_cogex/client/neo4j_client.py
@@ -941,6 +941,61 @@ class Neo4jClient:
         query = """MATCH(n) DETACH DELETE n"""
         return self.create_tx(query)
 
+    def delete_nodes_by_label(
+        self, node_label: str, batch_size: Optional[int] = 10_000
+    ):
+        """Delete nodes by their labels
+
+        Parameters
+        ----------
+        node_label :
+            The label of the nodes to delete.
+        batch_size :
+            The number of nodes to delete in each transaction. Default: 10,000.
+            Set to 0 or None to skip batching and delete all matching nodes in a
+            single transaction.
+        """
+        query = f"MATCH (n:{node_label}) CALL (n) {{ DELETE n }}"
+        if batch_size and batch_size > 0:
+            query += f" IN TRANSACTIONS OF {batch_size}"
+
+        # Implicit transaction needed for batching
+        with self.driver.session() as session:
+            session.run(query)
+
+    def delete_relationships_by_type(
+        self,
+        relationship_type: str,
+        start_label: Optional[str] = None,
+        end_label: Optional[str] = None,
+        batch_size: Optional[int] = 10_000
+    ):
+        """Delete relationships by their type, optionally match on labels
+
+        Parameters
+        ----------
+        relationship_type :
+            The type of the relationships to delete.
+        start_label :
+            The label of the start node in the relationship.
+        end_label :
+            The label of the end node in the relationship.
+        batch_size :
+            The number of relationships to delete in each transaction. Default:
+            10,000. Set to 0 or None to skip batching and delete all matching
+            relationships in a single transaction.
+        """
+        start_label = f":{start_label}" if start_label else ""
+        end_label = f":{end_label}" if end_label else ""
+        query = f"MATCH ({start_label})-[r:{relationship_type}]->({end_label})"
+        query += " CALL (r) {{ DELETE r }}"
+        if batch_size and batch_size > 0:
+            query += f" IN TRANSACTIONS OF {batch_size}"
+
+        # Implicit transaction needed when using ... IN TRANSACTIONS OF ...
+        with self.driver.session() as session:
+            session.run(query)
+
     def create_nodes(self, nodes: List[Node]):
         """Create a set of new graph nodes."""
         nodes_str = ",\n".join([str(n) for n in nodes])

--- a/src/indra_cogex/sources/partial_ingestion.py
+++ b/src/indra_cogex/sources/partial_ingestion.py
@@ -1,48 +1,83 @@
-"""An API for partial node ingestion via Cypher LOAD CSV.
+"""An API for partial node ingestion via Cypher's LOAD CSV.
 
-For node and edge files produced by the cogex processors with neo4j-admin import
-format, this module builds and runs batched MERGE queries when only a subset of
-nodes needs to be loaded into an existing database.
+For node and edge files produced by the cogex source processors with neo4j-admin
+import file header format, this module builds and runs batched MERGE or CREATE
+queries from specific files. This provides an opportunity to only a subset of
+nodes or relationships into an existing database.
+
+In order to be able to ingest CSV files using Cypher queries, the following
+settings need to be set for Neo4j:
+Writes to the database must be enabled (see
+https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_server.databases.default_to_read_only,
+https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_server.databases.read_only, and
+https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_server.databases.writable)
+
+Optionally, a third setting which allows global file loading can also be set.
+This allows file loading outside the default import directory (e.g.,
+/var/lib/neo4j/import/ on Linux). See more at:
+https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_dbms.security.allow_csv_import_from_file_urls
+
+Read more about the LOAD CSV Cypher command at
+https://neo4j.com/docs/cypher-manual/current/clauses/load-csv/
+
+
+Examples:
+---------
+
+Node example:
+query = \"""\
+LOAD CSV WITH HEADERS FROM 'file:///nodes_ClinicalTrial.tsv.gz' AS row FIELDTERMINATOR '\t'
+CALL (row) {
+  MERGE (n:ClinicalTrial {id: row['id:ID']})
+  SET n += {
+    completion_year:             toInteger(row['completion_year:int']),
+    completion_year_anticipated: toBoolean(row['completion_year_anticipated:boolean']),
+    last_update_year:            toInteger(row['last_update_year:int']),
+    phase:                       toInteger(row['phase:int']),
+    randomized:                  toBoolean(row['randomized:boolean']),
+    start_year:                  toInteger(row['start_year:int']),
+    start_year_anticipated:      toBoolean(row['start_year_anticipated:boolean']),
+    status:                      row['status'],
+    study_type:                  row['study_type'],
+    why_stopped:                 row['why_stopped']
+    // Hypothetical float vector property -
+    my_array:                    CASE row['my_array:float[]']
+                                 WHEN '' THEN null
+                                 ELSE [x IN split(row['my_array:float[]'], ';') | toFloat(x)] END
+  }
+} IN TRANSACTIONS OF 10000 ROWS;\"""
+
+Edge example for tested_in relationship types:
+``
+LOAD CSV WITH HEADERS FROM 'file:///edges_clinicaltrials_tested_in.tsv.gz' AS row FIELDTERMINATOR '\t'
+CALL (row) {
+  MATCH (a:BioEntity {id: row[':START_ID']})
+  MATCH (b:ClinicalTrial {id: row[':END_ID']})
+  MERGE (a)-[r:tested_in]->(b)
+  SET r += {
+    gilda: toBoolean(row['gilda:boolean']),
+    ctgov: toBoolean(row['ctgov:boolean'])
+  }
+} IN TRANSACTIONS OF 10000 ROWS;
+``
+
+In order to create parallel edges, the MERGE clause can be replaced with
+CREATE, which will simply add another relationship. Additionally, or
+alternatively, to distinguish parallel relationships by data property, that data
+property is added to the relationship MERGE or CREATE clause:
+``
+LOAD CSV WITH HEADERS FROM 'file:///has_publication_edges.tsv.gz' AS row
+FIELDTERMINATOR '\t'
+CALL (row) {
+  MATCH (a:ClinicalTrial {id: row[':START_ID']})
+  MATCH (b:Publication {id: row[':END_ID']})
+  MERGE (a)-[r:has_publication {source: row['source']}]->(b)
+  SET r += {
+    ref_type: CASE row['ref_type'] WHEN '' THEN null ELSE row['ref_type'] END
+  }
+} IN TRANSACTIONS OF 10000 ROWS;
+``
 """
-
-
-# Node example:
-# ct_query = """\
-# LOAD CSV WITH HEADERS FROM 'file:///nodes_ClinicalTrial.tsv.gz' AS row FIELDTERMINATOR '\t'
-# CALL (row) {
-#   MERGE (n:ClinicalTrial {id: row['id:ID']})
-#   SET n += {
-#     completion_year:             toInteger(row['completion_year:int']),
-#     completion_year_anticipated: toBoolean(row['completion_year_anticipated:boolean']),
-#     last_update_year:            toInteger(row['last_update_year:int']),
-#     phase:                       toInteger(row['phase:int']),
-#     randomized:                  toBoolean(row['randomized:boolean']),
-#     start_year:                  toInteger(row['start_year:int']),
-#     start_year_anticipated:      toBoolean(row['start_year_anticipated:boolean']),
-#     status:                      row['status'],
-#     study_type:                  row['study_type'],
-#     why_stopped:                 row['why_stopped']
-#     // Hypothetical float vector property -
-#     my_array:                    CASE row['my_array:float[]']
-#                                  WHEN '' THEN null
-#                                  ELSE [x IN split(row['my_array:float[]'], ';') | toFloat(x)] END
-#     // String vector
-#   }
-# } IN TRANSACTIONS OF 10000 ROWS;"""
-#
-# Edge example:
-# query_tested_in = """\
-# LOAD CSV WITH HEADERS FROM 'file:///edges_clinicaltrials_tested_in.tsv.gz' AS row FIELDTERMINATOR '\t'
-# CALL (row) {
-#   MATCH (a:BioEntity {id: row[':START_ID']})
-#   MATCH (b:ClinicalTrial {id: row[':END_ID']})
-#   MERGE (a)-[r:tested_in]->(b)
-#   SET r += {
-#     gilda: toBoolean(row['gilda:boolean']),
-#     mesh:  toBoolean(row['mesh:boolean'])
-#   }
-# } IN TRANSACTIONS OF 10000 ROWS;"""
-
 
 import csv
 import gzip
@@ -101,7 +136,20 @@ _SCALAR_TYPE_CONVERSIONS = {
 
 
 def read_file_headers(file_path: str | Path) -> list[str]:
-    """Read the header row from a gzipped neo4j-admin node TSV file."""
+    """Read the file header row from a gzipped TSV file
+
+    Parameters
+    ----------
+    file_path :
+        Path to the gzipped TSV file. Headers are assumed to be on the first
+        line of the file.
+
+    Returns
+    -------
+    :
+        A list of strings containing the headers from the file in the order they
+        appear in the file.
+    """
     with gzip.open(file_path, "rt") as fh:
         return next(csv.reader(fh, delimiter="\t"))
 
@@ -167,7 +215,8 @@ def format_set_clauses(property_headers: list[str]) -> str:
     -------
     :
         A string containing the property assignments for the SET clause, or an
-        empty string if there are no properties to set.
+        empty string if there are no properties to set. The string is indented
+        by 8 spaces and each property assignment is on a new line.
     """
     lines = [_set_expression(header) for header in property_headers]
     return ",\n".join(f"        {line}" for line in lines) if lines else ""
@@ -180,7 +229,34 @@ def build_node_ingestion_query(
     batch_size: int = 10_000,
     import_anywhere: bool = False,
 ) -> str:
-    """Build a batched LOAD CSV query for ingesting nodes of a single label."""
+    """Build a batched LOAD CSV query for ingesting nodes of a single label
+
+    Parameters
+    ----------
+    label :
+        The Neo4j label for all nodes in the file. Note: hard coding the label
+        greatly speeds up ingestion, and it is assumed the TSV file is of only
+        one label. To split up the node file per label, see
+        ``split_node_file_by_label``.
+    file_path :
+        Path to the gzipped TSV file.
+    headers :
+        The headers from the file to use in creating the query. If not provided,
+        they will be read from the file and all headers will be used.
+    batch_size :
+        Number of rows per sub-transaction (default: 10,000).
+    import_anywhere :
+        If True, the file will be imported from the given path. If False, the
+        file is assumed to be in Neo4j's import directory e.g.,
+        ``/var/lib/neo4j/import/`` on Linux. Note: this setting is only used to
+        adapt the file path used in the query, and does not control the Neo4j
+        instance's configuration.
+
+    Returns
+    -------
+    :
+        A string containing the Cypher query to ingest the nodes with.
+    """
     if headers is None:
         headers = read_file_headers(file_path)
     validate_headers(headers)
@@ -220,8 +296,7 @@ def ingest_nodes_from_file(
     client :
         The client to use to ingest the nodes.
     file_path :
-        Path to the gzipped TSV file. Must be located in Neo4j's import
-        directory (``/var/lib/neo4j/import/``).
+        Path to the gzipped TSV file.
     label :
         The Neo4j label for all nodes in the file. If omitted, inferred from
         the file name as ``nodes_<label>.tsv.gz``. Note: This assumes there is
@@ -274,6 +349,70 @@ def build_relationship_ingestion_query(
     parallel_properties: Optional[list[str]] = None,
 ) -> str:
     """Build a batched LOAD CSV query for ingesting relationships of a single type.
+
+    Parameters
+    ----------
+    relationship_type :
+        The Neo4j relationship type for all relations in the file. Note: hard
+        coding the relationship type greatly speeds up ingestion, and it is
+        assumed the TSV file is of only one type. To split up the relationship
+        file per type, see ``split_edge_file_by_type``.
+    file_path :
+        Path to the gzipped TSV file.
+    headers :
+        The headers from the file to use in creating the query. If not provided,
+        they will be read from the file and all headers will be used.
+    start_node_label :
+        The label of the start node for the relationships.
+    end_node_label :
+        The label of the end node for the relationships.
+    batch_size :
+        Number of rows per sub-transaction (default: 10,000).
+    import_anywhere :
+        If True, the file will be imported from the given path. If False, the
+        file is assumed to be in Neo4j's import directory e.g.,
+        ``/var/lib/neo4j/import/`` on Linux. Note: this setting is only used to
+        adapt the file path used in the query, and does not control the Neo4j
+        instance's configuration.
+    parallel_edges :
+        If True, creates parallel edges instead of merging.
+    parallel_properties :
+        List of properties to use for parallel edges.
+
+    Returns
+    -------
+    :
+        A string containing the Cypher query to ingest the relationships with.
+
+    Examples
+    --------
+    Example relationship file headers and their corresponding query (using
+    default values):
+
+    Header: `:START_ID`, `:END_ID`, `:TYPE`, and `weight:float`
+    Query:
+    ``LOAD CSV WITH HEADERS FROM 'file:///edges.tsv.gz' AS row
+    FIELDTERMINATOR '\\t'
+    CALL (row) {
+        MATCH (a:StartNode {id: row[':START_ID']})
+        MATCH (b:EndNode {id: row[':END_ID']})
+        MERGE (a)-[n:rel_type]->(b)
+        SET n += {
+            weight: toFloat(row['weight:float'])
+        }
+    } IN TRANSACTIONS OF 10000 ROWS;``
+
+    Header: `:START_ID`, `:END_ID`, `:TYPE`, and `embedding:float[]`
+    ``LOAD CSV WITH HEADERS FROM 'file:///edges.tsv.gz' AS row
+    FIELDTERMINATOR '\\t'
+    CALL (row) {
+        MATCH (a:StartNode {id: row[':START_ID']})
+        MATCH (b:EndNode {id: row[':END_ID']})
+        MERGE (a)-[n:rel_type]->(b)
+        SET n += {
+            embedding: CASE row['embedding:float[]'] WHEN '' THEN null ELSE [x IN split(row['embedding:float[]'], ';') | toFloat(x)] END
+        }
+    } IN TRANSACTIONS OF 10000 ROWS;``
     """
     # Validate headers and check for the mandatory columns for relationships
     if headers is None:
@@ -336,14 +475,14 @@ def split_edge_file_by_type(
     file_path :
         Path to the gzipped TSV file
     output_dir :
-        Directory to write the split files to. If not provided, writes to same
-        path as the input relationship file
+        Directory to write the split files to. If not provided, writes to the
+         same directory as the input relationship file
 
     Returns
     -------
     :
         A dictionary where the key is the relationship type and the value is the
-        path to the split file
+        path to the split file for that relationship type
     """
     file_path = Path(file_path)
     input_lines = 0

--- a/src/indra_cogex/sources/partial_ingestion.py
+++ b/src/indra_cogex/sources/partial_ingestion.py
@@ -1,19 +1,19 @@
-"""An API for partial node ingestion via Cypher's LOAD CSV.
+"""An API for partial node and relationship ingestion via Cypher's LOAD CSV.
 
 For node and edge files produced by the cogex source processors with neo4j-admin
 import file header format, this module builds and runs batched MERGE or CREATE
-queries from specific files. This provides an opportunity to only a subset of
-nodes or relationships into an existing database.
+queries from specific files. This makes it possible to ingest a subset of nodes
+or relationships into an existing database.
 
-In order to be able to ingest CSV files using Cypher queries, the following
-settings need to be set for Neo4j:
-Writes to the database must be enabled (see
+In order to be able to ingest CSV files using Cypher queries, the database needs
+to be writable. See
 https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_server.databases.default_to_read_only,
-https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_server.databases.read_only, and
-https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_server.databases.writable)
+https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_server.databases.read_only,
+and
+https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_server.databases.writable.
 
-Optionally, a third setting which allows global file loading can also be set.
-This allows file loading outside the default import directory (e.g.,
+Optionally, a setting which allows global file loading can also be set, which
+allows file loading outside the default import directory (e.g.,
 /var/lib/neo4j/import/ on Linux). See more at:
 https://neo4j.com/docs/operations-manual/current/configuration/configuration-settings/#config_dbms.security.allow_csv_import_from_file_urls
 
@@ -23,33 +23,35 @@ https://neo4j.com/docs/cypher-manual/current/clauses/load-csv/
 
 Examples:
 ---------
+Example query for a node file containing ClinicalTrial nodes:
 
-Node example:
-query = \"""\
-LOAD CSV WITH HEADERS FROM 'file:///nodes_ClinicalTrial.tsv.gz' AS row FIELDTERMINATOR '\t'
+LOAD CSV WITH HEADERS FROM 'file:///nodes_ClinicalTrial.tsv.gz' AS row
+FIELDTERMINATOR '\t'
 CALL (row) {
-  MERGE (n:ClinicalTrial {id: row['id:ID']})
-  SET n += {
-    completion_year:             toInteger(row['completion_year:int']),
-    completion_year_anticipated: toBoolean(row['completion_year_anticipated:boolean']),
-    last_update_year:            toInteger(row['last_update_year:int']),
-    phase:                       toInteger(row['phase:int']),
-    randomized:                  toBoolean(row['randomized:boolean']),
-    start_year:                  toInteger(row['start_year:int']),
-    start_year_anticipated:      toBoolean(row['start_year_anticipated:boolean']),
-    status:                      row['status'],
-    study_type:                  row['study_type'],
-    why_stopped:                 row['why_stopped']
-    // Hypothetical float vector property -
-    my_array:                    CASE row['my_array:float[]']
-                                 WHEN '' THEN null
-                                 ELSE [x IN split(row['my_array:float[]'], ';') | toFloat(x)] END
-  }
-} IN TRANSACTIONS OF 10000 ROWS;\"""
+    MERGE (n:ClinicalTrial {id: row['id:ID']})
+    SET n += {
+        completion_year:             toInteger(row['completion_year:int']),
+        completion_year_anticipated: toBoolean(row['completion_year_anticipated:boolean']),
+        last_update_year:            toInteger(row['last_update_year:int']),
+        phase:                       toInteger(row['phase:int']),
+        randomized:                  toBoolean(row['randomized:boolean']),
+        start_year:                  toInteger(row['start_year:int']),
+        start_year_anticipated:      toBoolean(row['start_year_anticipated:boolean']),
+        status:                      row['status'],
+        study_type:                  row['study_type'],
+        why_stopped:                 row['why_stopped']
+        // Hypothetical float vector property
+        my_array:                    CASE row['my_array:float[]']
+                                     WHEN '' THEN null
+                                     ELSE [x IN split(row['my_array:float[]'], ';') | toFloat(x)] END
+    }
+} IN TRANSACTIONS OF 10000 ROWS;
+
 
 Edge example for tested_in relationship types:
-``
-LOAD CSV WITH HEADERS FROM 'file:///edges_clinicaltrials_tested_in.tsv.gz' AS row FIELDTERMINATOR '\t'
+
+LOAD CSV WITH HEADERS FROM 'file:///edges_clinicaltrials_tested_in.tsv.gz' AS row
+FIELDTERMINATOR '\t'
 CALL (row) {
   MATCH (a:BioEntity {id: row[':START_ID']})
   MATCH (b:ClinicalTrial {id: row[':END_ID']})
@@ -59,13 +61,13 @@ CALL (row) {
     ctgov: toBoolean(row['ctgov:boolean'])
   }
 } IN TRANSACTIONS OF 10000 ROWS;
-``
+
 
 In order to create parallel edges, the MERGE clause can be replaced with
 CREATE, which will simply add another relationship. Additionally, or
 alternatively, to distinguish parallel relationships by data property, that data
 property is added to the relationship MERGE or CREATE clause:
-``
+
 LOAD CSV WITH HEADERS FROM 'file:///has_publication_edges.tsv.gz' AS row
 FIELDTERMINATOR '\t'
 CALL (row) {
@@ -76,7 +78,11 @@ CALL (row) {
     ref_type: CASE row['ref_type'] WHEN '' THEN null ELSE row['ref_type'] END
   }
 } IN TRANSACTIONS OF 10000 ROWS;
-``
+
+
+These two ways of creating (or not creating) parallel relationships are
+controlled by the parameters ``write_mode`` and ``parallel_properties`` in
+``ingest_relations_from_file_by_type``.
 """
 
 import csv

--- a/src/indra_cogex/sources/partial_ingestion.py
+++ b/src/indra_cogex/sources/partial_ingestion.py
@@ -184,13 +184,13 @@ def build_node_ingestion_query(
     if headers is None:
         headers = read_file_headers(file_path)
     validate_headers(headers)
-    for mandatory_header in MANDATORY_NODE_COLUMNS:
-        if mandatory_header not in headers:
-            raise ValueError(
-                f"Node file headers must include '{mandatory_header}' as one of "
-                f"the mandatory headers. The mandatory headers are "
-                f"{', '.join(MANDATORY_NODE_COLUMNS)}"
-            )
+    if not set(headers) & MANDATORY_NODE_COLUMNS == MANDATORY_NODE_COLUMNS:
+        missing_headers = MANDATORY_NODE_COLUMNS - set(headers)
+        raise ValueError(
+            f"Node file headers must include at least "
+            f"{', '.join(MANDATORY_NODE_COLUMNS)}. {file_path} is "
+            f"missing {', '.join(missing_headers)}."
+        )
 
     property_headers = [h for h in headers if h not in MANDATORY_NODE_COLUMNS]
     set_clauses = format_set_clauses(property_headers)

--- a/src/indra_cogex/sources/partial_ingestion.py
+++ b/src/indra_cogex/sources/partial_ingestion.py
@@ -1,0 +1,224 @@
+"""An API for partial node ingestion via Cypher LOAD CSV.
+
+For node and edge files produced by the cogex processors with neo4j-admin import
+format, this module builds and runs batched MERGE queries when only a subset of
+nodes needs to be loaded into an existing database.
+"""
+
+
+# Node example:
+# ct_query = """\
+# LOAD CSV WITH HEADERS FROM 'file:///nodes_ClinicalTrial.tsv.gz' AS row FIELDTERMINATOR '\t'
+# CALL (row) {
+#   MERGE (n:ClinicalTrial {id: row['id:ID']})
+#   SET n += {
+#     completion_year:             toInteger(row['completion_year:int']),
+#     completion_year_anticipated: toBoolean(row['completion_year_anticipated:boolean']),
+#     last_update_year:            toInteger(row['last_update_year:int']),
+#     phase:                       toInteger(row['phase:int']),
+#     randomized:                  toBoolean(row['randomized:boolean']),
+#     start_year:                  toInteger(row['start_year:int']),
+#     start_year_anticipated:      toBoolean(row['start_year_anticipated:boolean']),
+#     status:                      row['status'],
+#     study_type:                  row['study_type'],
+#     why_stopped:                 row['why_stopped']
+#     // Hypothetical float vector property -
+#     my_array:                    CASE row['my_array:float[]']
+#                                  WHEN '' THEN null
+#                                  ELSE [x IN split(row['my_array:float[]'], ';') | toFloat(x)] END
+#     // String vector
+#   }
+# } IN TRANSACTIONS OF 10000 ROWS;"""
+#
+# Edge example:
+# query_tested_in = """\
+# LOAD CSV WITH HEADERS FROM 'file:///edges_clinicaltrials_tested_in.tsv.gz' AS row FIELDTERMINATOR '\t'
+# CALL (row) {
+#   MATCH (a:BioEntity {id: row[':START_ID']})
+#   MATCH (b:ClinicalTrial {id: row[':END_ID']})
+#   MERGE (a)-[r:tested_in]->(b)
+#   SET r += {
+#     gilda: toBoolean(row['gilda:boolean']),
+#     mesh:  toBoolean(row['mesh:boolean'])
+#   }
+# } IN TRANSACTIONS OF 10000 ROWS;"""
+
+
+import csv
+import gzip
+import logging
+from pathlib import Path
+from typing import Optional
+
+from indra_cogex.client import Neo4jClient
+from indra_cogex.sources.processor import validate_headers
+
+
+logger = logging.getLogger(__name__)
+
+
+NODE_INGESTION_QUERY = """\
+LOAD CSV WITH HEADERS FROM 'file://{file_name}' AS row
+FIELDTERMINATOR '\\t'
+CALL (row) {{
+  MERGE (n:{label} {{id: row['id:ID']}}){set_clause}
+}} IN TRANSACTIONS OF {batch_size} ROWS
+"""
+
+# Optional SET clause for property assignments. If there are no properties to
+# set, this will be empty.
+SET_CLAUSE = """
+  SET n += {{
+{set_clauses}
+  }}"""
+
+MANDATORY_HEADERS = {"id:ID", ":LABEL"}
+
+_SCALAR_TYPE_CONVERSIONS = {
+    "int": "toInteger",
+    "integer": "toInteger",
+    "long": "toInteger",
+    "short": "toInteger",
+    "byte": "toInteger",
+    "float": "toFloat",
+    "double": "toFloat",
+    "boolean": "toBoolean",
+}
+
+
+def read_file_headers(file_path: str | Path) -> list[str]:
+    """Read the header row from a gzipped neo4j-admin node TSV file."""
+    with gzip.open(file_path, "rt") as fh:
+        return next(csv.reader(fh, delimiter="\t"))
+
+
+def _row_getter(dtype: Optional[str], header: str) -> str:
+    # Helper for format the right hand side of a SET clause assignment. If the
+    # property is an array, we need to split the string and convert each
+    # element for non-string arrays. If it's a scalar, we just convert it
+    # directly.
+    conversion = _SCALAR_TYPE_CONVERSIONS.get(dtype) if dtype else None
+
+    # Array value - split on ';'
+    if header.endswith("[]"):
+        array_set = f"CASE row['{header}'] WHEN '' THEN null "
+        array = "split(row['{header}'], ';')"
+        # Conversion needed: convert per element in array
+        if conversion:
+            array_set += f"ELSE [x IN {array} | {conversion}(x)] END"
+        # Otherwise, user array as is
+        else:
+            array_set += f"ELSE {array} END"
+        return array_set
+
+    # Scalar value
+    else:
+        if conversion:
+            return f"{conversion}(row['{header}'])"
+        return f"row['{header}']"
+
+
+def _set_expression(header: str) -> str:
+    # Create one SET expression e.g.,
+    # 'prop_name: row["prop_header"]'
+    # 'prop_name: toInteger(row["prop_header:int"])'
+    # 'prop_name: [x IN split(row["prop_header:int[]"], ";") | toInteger(x)]'
+    if ":" in header:
+        prop_name, dtype = header.split(":", 1)
+    else:
+        prop_name, dtype = header, None
+    if "." in prop_name:  # todo: check for other special characters that need escaping
+        prop_name = f"`{prop_name}`"  # Escape property names using backticks
+
+    # Strip array notation from dtype
+    if dtype and dtype.endswith("[]"):
+            dtype = dtype[:-2]
+
+    return f"{prop_name}: {_row_getter(dtype, header)}"
+
+
+def format_set_clauses_node(headers: list[str]) -> str:
+    """Build the property assignments for the SET clause from TSV headers."""
+    property_headers = [h for h in headers if h not in MANDATORY_HEADERS]
+    lines = [_set_expression(header) for header in property_headers]
+    return ",\n".join(f"    {line}" for line in lines) if lines else ""
+
+
+def build_node_ingestion_query(
+    label: str,
+    file_name: str,
+    headers: list[str],
+    batch_size: int = 10_000,
+) -> str:
+    """Build a batched LOAD CSV query for ingesting nodes of a single label."""
+    validate_headers(headers)
+    for mandatory_header in MANDATORY_HEADERS:
+        if mandatory_header not in headers:
+            raise ValueError(f"Node file headers must include '{mandatory_header}'")
+
+    set_clauses = format_set_clauses_node(headers)
+    set_clause = SET_CLAUSE.format(set_clauses=set_clauses) if set_clauses else ""
+    return NODE_INGESTION_QUERY.format(
+        label=label,
+        file_name=file_name,
+        set_clause=set_clause,
+        batch_size=batch_size,
+    )
+
+
+def ingest_nodes_from_file(
+    client: Neo4jClient,
+    file_path: str | Path,
+    label: Optional[str] = None,
+    batch_size: int = 10_000,
+):
+    """Ingest nodes from a neo4j-admin-format TSV file into the database.
+
+    Parameters
+    ----------
+    client :
+        The client to use to ingest the nodes.
+    file_path :
+        Path to the gzipped TSV file. Must be located in Neo4j's import
+        directory (``/var/lib/neo4j/import/``).
+    label :
+        The Neo4j label for all nodes in the file. If omitted, inferred from
+        the file name as ``nodes_<label>.tsv.gz``. Note: This assumes there is
+        only one label.
+    batch_size :
+        Number of rows per sub-transaction (default: 10,000).
+    """
+    file_path = Path(file_path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"File not found: {file_path}")
+    import_dir = Path("/var/lib/neo4j/import/")
+    if not file_path.is_relative_to(import_dir):
+        raise ValueError(f"File must be in {import_dir}")
+    file_name = file_path.name
+    headers = read_file_headers(file_path)
+    if not label:
+        # Get the label from the file name: nodes_<label>.tsv.gz
+        if '_' in file_name:
+            label = file_name.split("_")[1].split(".")[0]
+        else:
+            type_col = headers.index(":LABEL")
+            if type_col >= 0:
+                with gzip.open(file_path, mode="rt") as f:
+                    reader = csv.reader(f, delimiter="\t")
+                    next(reader)  # skip header
+                    first_row = next(reader)
+                    label = first_row[type_col]
+            else:
+                raise ValueError(
+                    "Could not infer label from file name or :LABEL column. "
+                    "Please provide a label explicitly."
+                )
+    query = build_node_ingestion_query(
+        label=label,
+        file_name=file_name,
+        headers=headers,
+        batch_size=batch_size,
+    )
+    logger.info(f"Running ingestion query:\n{query}")
+    with client.driver.session() as session:
+        session.run(query)

--- a/src/indra_cogex/sources/partial_ingestion.py
+++ b/src/indra_cogex/sources/partial_ingestion.py
@@ -84,7 +84,7 @@ import gzip
 import logging
 from tqdm import tqdm
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Literal
 
 from indra_cogex.client import Neo4jClient
 from indra_cogex.sources.processor import validate_headers
@@ -93,6 +93,7 @@ from indra_cogex.sources.processor import validate_headers
 logger = logging.getLogger(__name__)
 
 
+WRITE_MODES = ["MERGE", "CREATE"]
 NODE_INGESTION_QUERY = """\
 LOAD CSV WITH HEADERS FROM 'file://{file_name}' AS row
 FIELDTERMINATOR '\\t'
@@ -345,7 +346,7 @@ def build_relationship_ingestion_query(
     headers: Optional[list[str]] = None,
     batch_size: int = 10_000,
     import_anywhere: bool = False,
-    parallel_edges: bool = False,
+    write_mode: Literal["MERGE", "CREATE"] = "MERGE",
     parallel_properties: Optional[list[str]] = None,
 ) -> str:
     """Build a batched LOAD CSV query for ingesting relationships of a single type.
@@ -374,8 +375,11 @@ def build_relationship_ingestion_query(
         ``/var/lib/neo4j/import/`` on Linux. Note: this setting is only used to
         adapt the file path used in the query, and does not control the Neo4j
         instance's configuration.
-    parallel_edges :
-        If True, creates parallel edges instead of merging.
+    write_mode :
+        The write mode for the relationships. Can be either "MERGE" or "CREATE".
+        With MERGE, if the relationship already exists, it will be updated with
+        the new properties. With CREATE, a new relationship will be created
+        regardless of existing relationships.
     parallel_properties :
         List of properties to use for parallel edges.
 
@@ -414,6 +418,10 @@ def build_relationship_ingestion_query(
         }
     } IN TRANSACTIONS OF 10000 ROWS;``
     """
+    if write_mode not in WRITE_MODES:
+        raise ValueError(
+            f"Invalid write mode: {write_mode}. Must be one of {', '.join(WRITE_MODES)}."
+        )
     # Validate headers and check for the mandatory columns for relationships
     if headers is None:
         headers = read_file_headers(file_path)
@@ -437,7 +445,6 @@ def build_relationship_ingestion_query(
 
     # Build the query
     property_headers = [h for h in headers if h not in MANDATORY_RELATIONSHIP_COLUMNS]
-    write_mode = "CREATE" if parallel_edges else "MERGE"
     if parallel_properties:
         parallel_props = " {" + ", ".join(
             [_set_expression(par_prop) for par_prop in parallel_properties]
@@ -555,7 +562,7 @@ def ingest_relations_from_file_by_type(
     relationship_type: Optional[str] = None,
     batch_size: int = 10_000,
     import_anywhere: bool = False,
-    parallel_edges: bool = False,
+    write_mode: Literal["MERGE", "CREATE"] = "MERGE",
     parallel_properties: Optional[list[str]] = None
 ):
     """Ingest relations from a neo4j-admin-format TSV file into the database.
@@ -588,10 +595,10 @@ def ingest_relations_from_file_by_type(
         ``/var/lib/neo4j/import/`` on Linux. Note: this setting is only used to
         adapt the file path used in the query, and does not control the Neo4j
         instance's configuration.
-    parallel_edges :
-        If True, duplicate relationships, defined as same start id, type, and
+    write_mode :
+        If "CREATE", duplicate relationships, defined as same start id, type, and
         end id (and properties in parallel_properties if provided), from the
-        input file will be ingested as parallel relationships. If False,
+        input file will be ingested as parallel relationships. If "MERGE",
         duplicate relationships will be overwritten by the last occurrence in
         the input file, unless parallel_properties is provided, in which case
         the relationships will be distinguished by the values of the properties
@@ -631,7 +638,7 @@ def ingest_relations_from_file_by_type(
         end_node_label=end_node_label,
         batch_size=batch_size,
         import_anywhere=import_anywhere,
-        parallel_edges=parallel_edges,
+        write_mode=write_mode,
         parallel_properties=parallel_properties,
     )
 

--- a/src/indra_cogex/sources/partial_ingestion.py
+++ b/src/indra_cogex/sources/partial_ingestion.py
@@ -232,9 +232,6 @@ def ingest_nodes_from_file(
     file_path = Path(file_path)
     if not file_path.exists():
         raise FileNotFoundError(f"File not found: {file_path}")
-    import_dir = Path("/var/lib/neo4j/import/")
-    if not file_path.is_relative_to(import_dir):
-        raise ValueError(f"File must be in {import_dir}")
     file_name = file_path.name
     headers = read_file_headers(file_path)
     if not label:

--- a/src/indra_cogex/sources/partial_ingestion.py
+++ b/src/indra_cogex/sources/partial_ingestion.py
@@ -62,16 +62,15 @@ NODE_INGESTION_QUERY = """\
 LOAD CSV WITH HEADERS FROM 'file://{file_name}' AS row
 FIELDTERMINATOR '\\t'
 CALL (row) {{
-  MERGE (n:{label} {{id: row['id:ID']}}){set_clause}
+    MERGE (n:{label} {{id: row['id:ID']}}){set_clause}
 }} IN TRANSACTIONS OF {batch_size} ROWS
 """
 
-# Optional SET clause for property assignments. If there are no properties to
-# set, this will be empty.
+# Optional SET clause for property assignments
 SET_CLAUSE = """
-  SET n += {{
+    SET n += {{
 {set_clauses}
-  }}"""
+    }}"""
 
 # Relationship query template. Note that the relationship variable is set to
 # 'n', this is to match the SET_CLAUSE template.
@@ -107,21 +106,21 @@ def read_file_headers(file_path: str | Path) -> list[str]:
         return next(csv.reader(fh, delimiter="\t"))
 
 
-def _row_getter(dtype: Optional[str], header: str) -> str:
-    # Helper for format the right hand side of a SET clause assignment. If the
-    # property is an array, we need to split the string and convert each
-    # element for non-string arrays. If it's a scalar, we just convert it
-    # directly.
+def _row_getter(header: str, dtype: Optional[str] = None) -> str:
+    # Helper for formatting the right hand side of a SET clause assignment. If
+    # the property is an array, the string representing it needs to be split
+    # into elements and possibly convert each element if it's a non-string
+    # array. If it's a scalar, convert it directly.
     conversion = _SCALAR_TYPE_CONVERSIONS.get(dtype) if dtype else None
 
     # Array value - split on ';'
     if header.endswith("[]"):
         array_set = f"CASE row['{header}'] WHEN '' THEN null "
-        array = "split(row['{header}'], ';')"
+        array = f"split(row['{header}'], ';')"
         # Conversion needed: convert per element in array
         if conversion:
             array_set += f"ELSE [x IN {array} | {conversion}(x)] END"
-        # Otherwise, user array as is
+        # Otherwise, use array as is
         else:
             array_set += f"ELSE {array} END"
         return array_set
@@ -134,12 +133,16 @@ def _row_getter(dtype: Optional[str], header: str) -> str:
 
 
 def _set_expression(header: str) -> str:
-    # Create one SET expression e.g.,
-    # 'prop_name: row["prop_header"]'
-    # 'prop_name: toInteger(row["prop_header:int"])'
-    # 'prop_name: [x IN split(row["prop_header:int[]"], ";") | toInteger(x)]'
+    # Create a SET expression for a property e.g.,
+    # prop_name: row["prop_name"]
+    # prop_name: toInteger(row["prop_name:int"])
+    # prop_name: [x IN split(row["prop_name:int[]"], ";") | toInteger(x)]
     if ":" in header:
         prop_name, dtype = header.split(":", 1)
+        if ":" in dtype:
+            raise ValueError(
+                f"Invalid header '{header}': multiple ':' characters found"
+            )
     else:
         prop_name, dtype = header, None
     if "." in prop_name:  # todo: check for other special characters that need escaping
@@ -149,33 +152,56 @@ def _set_expression(header: str) -> str:
     if dtype and dtype.endswith("[]"):
             dtype = dtype[:-2]
 
-    return f"{prop_name}: {_row_getter(dtype, header)}"
+    return f"{prop_name}: {_row_getter(header, dtype=dtype)}"
 
 
-def format_set_clauses_node(headers: list[str]) -> str:
-    """Build the property assignments for the SET clause from TSV headers."""
-    property_headers = [h for h in headers if h not in MANDATORY_HEADERS]
+def format_set_clauses(property_headers: list[str]) -> str:
+    """Build the property assignments for the SET clause from TSV headers
+
+    Parameters
+    ----------
+    property_headers :
+        The headers from the file to read the data properties from.
+
+    Returns
+    -------
+    :
+        A string containing the property assignments for the SET clause, or an
+        empty string if there are no properties to set.
+    """
     lines = [_set_expression(header) for header in property_headers]
-    return ",\n".join(f"    {line}" for line in lines) if lines else ""
+    return ",\n".join(f"        {line}" for line in lines) if lines else ""
 
 
 def build_node_ingestion_query(
     label: str,
-    file_name: str,
-    headers: list[str],
+    file_path: str | Path,
+    headers: Optional[list[str]] = None,
     batch_size: int = 10_000,
+    import_anywhere: bool = False,
 ) -> str:
     """Build a batched LOAD CSV query for ingesting nodes of a single label."""
+    if headers is None:
+        headers = read_file_headers(file_path)
     validate_headers(headers)
     for mandatory_header in MANDATORY_NODE_COLUMNS:
         if mandatory_header not in headers:
-            raise ValueError(f"Node file headers must include '{mandatory_header}'")
+            raise ValueError(
+                f"Node file headers must include '{mandatory_header}' as one of "
+                f"the mandatory headers. The mandatory headers are "
+                f"{', '.join(MANDATORY_NODE_COLUMNS)}"
+            )
 
-    set_clauses = format_set_clauses_node(headers)
+    property_headers = [h for h in headers if h not in MANDATORY_NODE_COLUMNS]
+    set_clauses = format_set_clauses(property_headers)
     set_clause = SET_CLAUSE.format(set_clauses=set_clauses) if set_clauses else ""
+    if import_anywhere:
+        file_import = Path(file_path).absolute().as_posix()
+    else:
+        file_import = "/" + Path(file_path).name
     return NODE_INGESTION_QUERY.format(
         label=label,
-        file_name=file_name,
+        file_name=file_import,
         set_clause=set_clause,
         batch_size=batch_size,
     )
@@ -216,13 +242,13 @@ def ingest_nodes_from_file(
         if '_' in file_name:
             label = file_name.split("_")[1].split(".")[0]
         else:
-            type_col = headers.index(":LABEL")
-            if type_col >= 0:
+            label_col = headers.index(":LABEL")
+            if label_col >= 0:
                 with gzip.open(file_path, mode="rt") as f:
                     reader = csv.reader(f, delimiter="\t")
                     next(reader)  # skip header
                     first_row = next(reader)
-                    label = first_row[type_col]
+                    label = first_row[label_col]
             else:
                 raise ValueError(
                     "Could not infer label from file name or :LABEL column. "
@@ -230,7 +256,7 @@ def ingest_nodes_from_file(
                 )
     query = build_node_ingestion_query(
         label=label,
-        file_name=file_name,
+        file_path=file_path,
         headers=headers,
         batch_size=batch_size,
     )

--- a/src/indra_cogex/sources/partial_ingestion.py
+++ b/src/indra_cogex/sources/partial_ingestion.py
@@ -47,6 +47,7 @@ nodes needs to be loaded into an existing database.
 import csv
 import gzip
 import logging
+from tqdm import tqdm
 from pathlib import Path
 from typing import Optional
 
@@ -72,7 +73,21 @@ SET_CLAUSE = """
 {set_clauses}
   }}"""
 
-MANDATORY_HEADERS = {"id:ID", ":LABEL"}
+# Relationship query template. Note that the relationship variable is set to
+# 'n', this is to match the SET_CLAUSE template.
+RELATIONSHIP_QUERY = """\
+LOAD CSV WITH HEADERS FROM 'file://{file_name}' AS row
+FIELDTERMINATOR '\\t'
+CALL (row) {{
+    MATCH (a:{start_label} {{id: row[':START_ID']}})
+    MATCH (b:{end_label} {{id: row[':END_ID']}})
+    {write_mode} (a)-[n:{rel_type}{parallel_prop}]->(b){set_clause}
+}} IN TRANSACTIONS OF {batch_size} ROWS
+"""
+
+
+MANDATORY_NODE_COLUMNS = {"id:ID", ":LABEL"}
+MANDATORY_RELATIONSHIP_COLUMNS = {":START_ID", ":END_ID", ":TYPE"}
 
 _SCALAR_TYPE_CONVERSIONS = {
     "int": "toInteger",
@@ -152,7 +167,7 @@ def build_node_ingestion_query(
 ) -> str:
     """Build a batched LOAD CSV query for ingesting nodes of a single label."""
     validate_headers(headers)
-    for mandatory_header in MANDATORY_HEADERS:
+    for mandatory_header in MANDATORY_NODE_COLUMNS:
         if mandatory_header not in headers:
             raise ValueError(f"Node file headers must include '{mandatory_header}'")
 
@@ -220,5 +235,249 @@ def ingest_nodes_from_file(
         batch_size=batch_size,
     )
     logger.info(f"Running ingestion query:\n{query}")
+    with client.driver.session() as session:
+        session.run(query)
+
+
+def build_relationship_ingestion_query(
+    relationship_type: str,
+    file_path: str | Path,
+    start_node_label: str,
+    end_node_label: str,
+    headers: Optional[list[str]] = None,
+    batch_size: int = 10_000,
+    import_anywhere: bool = False,
+    parallel_edges: bool = False,
+    parallel_properties: Optional[list[str]] = None,
+) -> str:
+    """Build a batched LOAD CSV query for ingesting relationships of a single type.
+    """
+    # Validate headers and check for the mandatory columns for relationships
+    if headers is None:
+        headers = read_file_headers(file_path)
+    validate_headers(headers)
+    if not set(headers) & MANDATORY_RELATIONSHIP_COLUMNS == MANDATORY_RELATIONSHIP_COLUMNS:
+        missing_headers = MANDATORY_RELATIONSHIP_COLUMNS - set(headers)
+        raise ValueError(
+            f"Relationship file headers must include at least "
+            f"{', '.join(MANDATORY_RELATIONSHIP_COLUMNS)}. {file_path} is "
+            f"missing {', '.join(missing_headers)}."
+        )
+    if parallel_properties:
+        if isinstance(parallel_properties, str):
+            parallel_properties = [parallel_properties]
+        for par_prop in parallel_properties:
+            if par_prop not in headers:
+                raise ValueError(
+                    f"Parallel property '{par_prop}' not found in file headers. "
+                    f"Available headers: {', '.join(headers)}"
+                )
+
+    # Build the query
+    property_headers = [h for h in headers if h not in MANDATORY_RELATIONSHIP_COLUMNS]
+    write_mode = "CREATE" if parallel_edges else "MERGE"
+    if parallel_properties:
+        parallel_props = " {" + ", ".join(
+            [_set_expression(par_prop) for par_prop in parallel_properties]
+        ) + "}"
+        property_headers = [h for h in property_headers if h not in parallel_properties]
+    else:
+        parallel_props = ""
+
+    set_clauses = format_set_clauses(property_headers)
+    if import_anywhere:
+        file_import = Path(file_path).absolute().as_posix()
+    else:
+        file_import = "/" + Path(file_path).name
+
+    query = RELATIONSHIP_QUERY.format(
+        file_name=file_import,
+        start_label=start_node_label,
+        end_label=end_node_label,
+        rel_type=relationship_type,
+        parallel_prop=parallel_props,
+        set_clause=SET_CLAUSE.format(set_clauses=set_clauses) if set_clauses else "",
+        batch_size=batch_size,
+        write_mode=write_mode,
+    )
+    return query
+
+
+def split_edge_file_by_type(
+    file_path: str | Path, output_dir: Optional[str | Path] = None
+) -> dict[str, Path]:
+    """Split a gzipped edge TSV file into multiple files by relationship type.
+
+    Parameters
+    ----------
+    file_path :
+        Path to the gzipped TSV file
+    output_dir :
+        Directory to write the split files to. If not provided, writes to same
+        path as the input relationship file
+
+    Returns
+    -------
+    :
+        A dictionary where the key is the relationship type and the value is the
+        path to the split file
+    """
+    file_path = Path(file_path)
+    input_lines = 0
+    with gzip.open(file_path, mode="rt") as f:
+        reader = csv.reader(f, delimiter="\t")
+        header = next(reader)
+        type_col = header.index(":TYPE")
+        if type_col < 0:
+            raise ValueError(f":TYPE column missing from {file_path}")
+        types = set()
+        for row in reader:
+            rel_type = row[type_col]
+            types.add(rel_type)
+            input_lines += 1
+
+    if len(types) == 1:
+        rel_type = types.pop()
+        if not rel_type:
+            raise ValueError(f"Relationship type column seems empty in {file_path}")
+        logger.info("Relationship file is already of single type")
+        return {rel_type: file_path}
+
+    if output_dir is None:
+        output_dir = file_path.parent
+    else:
+        output_dir = Path(output_dir)
+    file_name_prefix = file_path.name.split(".")[0]
+
+    # Split by file: output files are <file_name>_<rel_type>.tsv.gz
+    file_name_map = {
+        rel_type: output_dir / f"{file_name_prefix}_{rel_type}.tsv.gz"
+        for rel_type in types
+    }
+    with gzip.open(file_path, mode="rt") as f:
+        reader = csv.reader(f, delimiter="\t")
+        _ = next(reader)  # Header already read above
+
+        # Open all output files
+        file_io = {}
+        for rel_type, out_path in file_name_map.items():
+            fh = gzip.open(out_path, "wt")
+            csv_writer = csv.writer(fh, delimiter="\t")
+            csv_writer.writerow(header)
+            file_io[rel_type] = {"file_handle": fh, "csv_writer": csv_writer}
+
+        # Loop file and write to respective file
+        for row in tqdm(
+            reader,
+            total=input_lines,
+            unit="row",
+            unit_scale=True,
+            desc="Writing split files",
+        ):
+            rel_type = row[type_col]
+            type_writer = file_io[rel_type]["csv_writer"]
+            type_writer.writerow(row)
+
+        # Close all open files
+        for out_io in file_io.values():
+            out_io["file_handle"].close()
+
+    return file_name_map
+
+
+def ingest_relations_from_file_by_type(
+    client: Neo4jClient,
+    file_path: str | Path,
+    start_node_label: str,
+    end_node_label: str,
+    relationship_type: Optional[str] = None,
+    batch_size: int = 10_000,
+    import_anywhere: bool = False,
+    parallel_edges: bool = False,
+    parallel_properties: Optional[list[str]] = None
+):
+    """Ingest relations from a neo4j-admin-format TSV file into the database.
+
+    Parameters
+    ----------
+    client :
+        The client for the Neo4j connection to use when ingesting the relations
+    file_path :
+        Path to the gzipped TSV file holding the relationships to import. The
+        relationships are assumed to be of one type and start and end node
+        labels are assumed to have one label, respectively. This is to be able
+        to hard code the type and labels, which greatly speeds up ingestion.
+    start_node_label :
+        The node label of the start node for all relations in the file. Note:
+        it is assumed all starting nodes in the file have the same label.
+    end_node_label :
+        The node label of the end node for all relations in the file. Note:
+        it is assumed all ending nodes in the file have the same label.
+    relationship_type :
+        The Neo4j relationship type for all relations in the file. Note: hard
+        coding the relationship type greatly speeds up ingestion, and it is
+        assumed the TSV file is of only one type. To split up the relationship
+        file per type, see ``split_edge_file_by_type``.
+    batch_size :
+        Number of rows per sub-transaction (default: 10,000).
+    import_anywhere :
+        If True, the file will be imported from the given path. If False, the
+        file is assumed to be in Neo4j's import directory e.g.,
+        ``/var/lib/neo4j/import/`` on Linux. Note: this setting is only used to
+        adapt the file path used in the query, and does not control the Neo4j
+        instance's configuration.
+    parallel_edges :
+        If True, duplicate relationships, defined as same start id, type, and
+        end id (and properties in parallel_properties if provided), from the
+        input file will be ingested as parallel relationships. If False,
+        duplicate relationships will be overwritten by the last occurrence in
+        the input file, unless parallel_properties is provided, in which case
+        the relationships will be distinguished by the values of the properties
+        in parallel_properties.
+    parallel_properties :
+        List of file headers that should be used to distinguish parallel
+        relationships. If provided, a property match will be added for each of
+        these properties on the relationship MERGE clause.
+    """
+    file_path = Path(file_path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    headers = read_file_headers(file_path)
+    if not relationship_type:
+        # Get the relationship type from the file name: edges_<rel_type>.tsv.gz
+        if '_' in file_path.name:
+            relationship_type = file_path.name.split("_")[1].split(".")[0]
+        else:
+            type_col = headers.index(":TYPE")
+            if type_col >= 0:
+                with gzip.open(file_path, mode="rt") as f:
+                    reader = csv.reader(f, delimiter="\t")
+                    next(reader)  # skip header
+                    first_row = next(reader)
+                    relationship_type = first_row[type_col]
+            else:
+                raise ValueError(
+                    "Could not infer relationship type from file name or :TYPE "
+                    "column. Please provide a relationship type explicitly."
+                )
+    if isinstance(parallel_properties, str):
+        parallel_properties = [parallel_properties]
+
+    query = build_relationship_ingestion_query(
+        relationship_type=relationship_type,
+        file_path=file_path,
+        headers=headers,
+        start_node_label=start_node_label,
+        end_node_label=end_node_label,
+        batch_size=batch_size,
+        import_anywhere=import_anywhere,
+        parallel_edges=parallel_edges,
+        parallel_properties=parallel_properties,
+    )
+
+    logger.info(
+        f"Running ingestion query for relationship type '{relationship_type}':\n{query}"
+    )
     with client.driver.session() as session:
         session.run(query)

--- a/src/indra_cogex/sources/partial_ingestion.py
+++ b/src/indra_cogex/sources/partial_ingestion.py
@@ -467,23 +467,20 @@ def ingest_relations_from_file_by_type(
         raise FileNotFoundError(f"File not found: {file_path}")
 
     headers = read_file_headers(file_path)
+    # Get the relationship type from the file if not provided
     if not relationship_type:
-        # Get the relationship type from the file name: edges_<rel_type>.tsv.gz
-        if '_' in file_path.name:
-            relationship_type = file_path.name.split("_")[1].split(".")[0]
+        type_col = headers.index(":TYPE")
+        if type_col >= 0:
+            with gzip.open(file_path, mode="rt") as f:
+                reader = csv.reader(f, delimiter="\t")
+                next(reader)  # skip header
+                first_row = next(reader)
+                relationship_type = first_row[type_col]
         else:
-            type_col = headers.index(":TYPE")
-            if type_col >= 0:
-                with gzip.open(file_path, mode="rt") as f:
-                    reader = csv.reader(f, delimiter="\t")
-                    next(reader)  # skip header
-                    first_row = next(reader)
-                    relationship_type = first_row[type_col]
-            else:
-                raise ValueError(
-                    "Could not infer relationship type from file name or :TYPE "
-                    "column. Please provide a relationship type explicitly."
-                )
+            raise ValueError(
+                "Could not infer relationship type from file name or :TYPE "
+                "column. Please provide a relationship type explicitly."
+            )
     if isinstance(parallel_properties, str):
         parallel_properties = [parallel_properties]
 

--- a/src/indra_cogex/sources/processor.py
+++ b/src/indra_cogex/sources/processor.py
@@ -42,6 +42,7 @@ from indra_cogex.sources.processor_util import (
 
 __all__ = [
     "Processor",
+    "validate_headers",
 ]
 
 logger = logging.getLogger(__name__)
@@ -496,12 +497,13 @@ def validate_headers(headers: Iterable[str]) -> None:
     for header in headers:
         # If : is in the header and there is something after it check if
         # it's a valid data type
-        if ":" in header and header.split(":")[1]:
-            dtype = header.split(":")[1]
+        if ":" in header:
+            dtype = header.split(":", maxsplit=1)[1]
 
             # Strip trailing '[]' for array types
             if dtype.endswith("[]"):
                 dtype = dtype[:-2]
+                # Catch 'prop_name:[]'
                 if not dtype:
                     raise ValueError(f"Data type value for header '{header}' is empty!")
 

--- a/tests/test_partial_ingestion.py
+++ b/tests/test_partial_ingestion.py
@@ -18,7 +18,7 @@ def test_read_file_headers():
     with tempfile.NamedTemporaryFile(suffix=".tsv.gz") as temp_file:
         with gzip.open(temp_file.name, "wt") as f:
             csv_writer = csv.writer(f, delimiter="\t")
-            csv_writer.writerow(["header1","header2","header3"])
+            csv_writer.writerow(["header1", "header2", "header3"])
 
         headers = read_file_headers(temp_file.name)
         assert headers == ["header1", "header2", "header3"]
@@ -84,7 +84,12 @@ def test_set_expression_escape_dot():
 
 
 def test_format_set_clauses():
-    property_headers = ["prop1", "prop2:int", "prop3:string[]", "prop4:boolean[]"]
+    property_headers = [
+        "prop1",
+        "prop2:int",
+        "prop3:string[]",
+        "prop4:boolean[]",
+    ]
     query_set_clause = format_set_clauses(property_headers)
     assert query_set_clause == """\
         prop1: row['prop1'],
@@ -361,9 +366,15 @@ def test_split_edge_file_by_type():
         with gzip.open(temp_file.name, "wt") as tsv_file:
             csv_writer = csv.writer(tsv_file, delimiter="\t")
             csv_writer.writerow(header)
-            csv_writer.writerow(["start1", "end1", "TYPE_A", "val1", "1", "a;b;c", "true;false"])
-            csv_writer.writerow(["start2", "end2", "TYPE_B", "val2", "2", "d;e;f", "false;true"])
-            csv_writer.writerow(["start3", "end3", "TYPE_A", "val3", "3", "g;h;i", "true;true"])
+            csv_writer.writerow(
+                ["start1", "end1", "TYPE_A", "val1", "1", "a;b;c", "true;false"]
+            )
+            csv_writer.writerow(
+                ["start2", "end2", "TYPE_B", "val2", "2", "d;e;f", "false;true"]
+            )
+            csv_writer.writerow(
+                ["start3", "end3", "TYPE_A", "val3", "3", "g;h;i", "true;true"]
+            )
         outfiles = split_edge_file_by_type(file_path=temp_file.name)
         assert len(outfiles) == 2
         assert {"TYPE_A", "TYPE_B"} == set(outfiles)
@@ -379,8 +390,24 @@ def test_split_edge_file_by_type():
             assert type_a_header == header
             data_rows = list(reader)
             assert len(data_rows) == 2
-            assert data_rows[0] == ["start1", "end1", "TYPE_A", "val1", "1", "a;b;c", "true;false"]
-            assert data_rows[1] == ["start3", "end3", "TYPE_A", "val3", "3", "g;h;i", "true;true"]
+            assert data_rows[0] == [
+                "start1",
+                "end1",
+                "TYPE_A",
+                "val1",
+                "1",
+                "a;b;c",
+                "true;false",
+            ]
+            assert data_rows[1] == [
+                "start3",
+                "end3",
+                "TYPE_A",
+                "val3",
+                "3",
+                "g;h;i",
+                "true;true",
+            ]
 
         with gzip.open(outfiles["TYPE_B"], "rt") as f:
             reader = csv.reader(f, delimiter="\t")
@@ -388,4 +415,12 @@ def test_split_edge_file_by_type():
             assert type_b_header == header
             data_rows = list(reader)
             assert len(data_rows) == 1
-            assert data_rows[0] == ["start2", "end2", "TYPE_B", "val2", "2", "d;e;f", "false;true"]
+            assert data_rows[0] == [
+                "start2",
+                "end2",
+                "TYPE_B",
+                "val2",
+                "2",
+                "d;e;f",
+                "false;true",
+            ]

--- a/tests/test_partial_ingestion.py
+++ b/tests/test_partial_ingestion.py
@@ -424,3 +424,191 @@ def test_split_edge_file_by_type():
                 "d;e;f",
                 "false;true",
             ]
+
+
+def test_node_ingestion_clinicaltrials():
+    # Testing a real-world example
+    with tempfile.NamedTemporaryFile(
+        suffix="_ClinicalTrial.tsv.gz"
+    ) as temp_file:
+        with gzip.open(temp_file.name, "wt") as tsv_file:
+            csv_writer = csv.writer(tsv_file, delimiter="\t")
+            csv_writer.writerow(
+                [
+                    "id:ID",
+                    ":LABEL",
+                    "completion_year:int",
+                    "completion_year_anticipated:boolean",
+                    "last_update_year:int",
+                    "phase:int",
+                    "randomized:boolean",
+                    "start_year:int",
+                    "start_year_anticipated:boolean",
+                    "status",
+                    "study_type",
+                    "why_stopped",
+                ]
+            )
+
+        headers = read_file_headers(temp_file.name)
+        query = build_node_ingestion_query(
+            label="ClinicalTrial",
+            file_path=temp_file.name,
+            headers=headers,
+            import_anywhere=False,
+        )
+        assert query == dedent("""\
+            LOAD CSV WITH HEADERS FROM 'file:///%s' AS row
+            FIELDTERMINATOR '\\t'
+            CALL (row) {
+                MERGE (n:ClinicalTrial {id: row['id:ID']})
+                SET n += {
+                    completion_year: toInteger(row['completion_year:int']),
+                    completion_year_anticipated: toBoolean(row['completion_year_anticipated:boolean']),
+                    last_update_year: toInteger(row['last_update_year:int']),
+                    phase: toInteger(row['phase:int']),
+                    randomized: toBoolean(row['randomized:boolean']),
+                    start_year: toInteger(row['start_year:int']),
+                    start_year_anticipated: toBoolean(row['start_year_anticipated:boolean']),
+                    status: row['status'],
+                    study_type: row['study_type'],
+                    why_stopped: row['why_stopped']
+                }
+            } IN TRANSACTIONS OF 10000 ROWS
+            """
+            ) % temp_file.name.split("/")[-1]
+
+
+def test_clinicaltrial_edges():
+    # Testing a real-world example of clinicaltrial edges
+    with tempfile.NamedTemporaryFile(
+        suffix=".tsv.gz"
+    ) as temp_file:
+        with gzip.open(temp_file.name, "wt") as tsv_file:
+            csv_writer = csv.writer(tsv_file, delimiter="\t")
+            csv_writer.writerows(
+                [
+                    [
+                        ":START_ID",
+                        ":END_ID",
+                        ":TYPE",
+                        "ctgov:boolean",
+                        "gilda:boolean",
+                        "ref_type",
+                        "source",
+                    ],
+                    [
+                        "chebi:10023",
+                        "clinicaltrials:NCT00003031",
+                        "tested_in",
+                        "true",
+                        "true",
+                        "",
+                        "",
+                    ],
+                    [
+                        "chebi:119915",
+                        "clinicaltrials:NCT01488149",
+                        "has_trial",
+                        "false",
+                        "true",
+                        "",
+                        "",
+                    ],
+                    [
+                        "clinicaltrials:NCT00000489",
+                        "pubmed:1512060",
+                        "has_publication",
+                        "",
+                        "",
+                        "BACKGROUND",
+                        "ctgov",
+                    ],
+                ]
+            )
+
+        split_edge_files = split_edge_file_by_type(file_path=temp_file.name)
+        assert len(split_edge_files) == 3
+        assert {"tested_in", "has_trial", "has_publication"} == set(
+            split_edge_files
+        )
+        tested_in_file_header = read_file_headers(split_edge_files["tested_in"])
+        tested_in_file_header.remove("ref_type")
+        tested_in_file_header.remove("source")
+        tested_in_query = build_relationship_ingestion_query(
+            relationship_type="tested_in",
+            file_path=split_edge_files["tested_in"],
+            start_node_label="BioEntity",
+            end_node_label="ClinicalTrial",
+            headers=tested_in_file_header,
+            import_anywhere=False,
+            parallel_edges=False,
+            parallel_properties=None,
+        )
+        assert tested_in_query == dedent("""\
+            LOAD CSV WITH HEADERS FROM 'file:///%s' AS row
+            FIELDTERMINATOR '\\t'
+            CALL (row) {
+                MATCH (a:BioEntity {id: row[':START_ID']})
+                MATCH (b:ClinicalTrial {id: row[':END_ID']})
+                MERGE (a)-[n:tested_in]->(b)
+                SET n += {
+                    ctgov: toBoolean(row['ctgov:boolean']),
+                    gilda: toBoolean(row['gilda:boolean'])
+                }
+            } IN TRANSACTIONS OF 10000 ROWS
+            """
+        ) % split_edge_files["tested_in"].name.split("/")[-1]
+
+        has_trial_file_header = read_file_headers(split_edge_files["has_trial"])
+        has_trial_file_header.remove("ref_type")
+        has_trial_file_header.remove("source")
+        has_trial_query = build_relationship_ingestion_query(
+            relationship_type="has_trial",
+            file_path=split_edge_files["has_trial"],
+            start_node_label="BioEntity",
+            end_node_label="ClinicalTrial",
+            headers=has_trial_file_header,
+            import_anywhere=False,
+            parallel_edges=False,
+            parallel_properties=None,
+        )
+        assert has_trial_query == dedent("""\
+        LOAD CSV WITH HEADERS FROM 'file:///%s' AS row
+        FIELDTERMINATOR '\\t'
+        CALL (row) {
+            MATCH (a:BioEntity {id: row[':START_ID']})
+            MATCH (b:ClinicalTrial {id: row[':END_ID']})
+            MERGE (a)-[n:has_trial]->(b)
+            SET n += {
+                ctgov: toBoolean(row['ctgov:boolean']),
+                gilda: toBoolean(row['gilda:boolean'])
+            }
+        } IN TRANSACTIONS OF 10000 ROWS
+        """) % split_edge_files["has_trial"].name.split("/")[-1]
+
+        has_publication_file_header = read_file_headers(split_edge_files["has_publication"])
+        has_publication_file_header.remove("ctgov:boolean")
+        has_publication_file_header.remove("gilda:boolean")
+        has_publication_query = build_relationship_ingestion_query(
+            relationship_type="has_publication",
+            file_path=split_edge_files["has_publication"],
+            start_node_label="ClinicalTrial",
+            end_node_label="Publication",
+            headers=has_publication_file_header,
+            import_anywhere=False,
+            parallel_edges=False,
+            parallel_properties=["source"],
+        )
+        assert has_publication_query == dedent("""\
+        LOAD CSV WITH HEADERS FROM 'file:///%s' AS row
+        FIELDTERMINATOR '\\t'
+        CALL (row) {
+            MATCH (a:ClinicalTrial {id: row[':START_ID']})
+            MATCH (b:Publication {id: row[':END_ID']})
+            MERGE (a)-[n:has_publication {source: row['source']}]->(b)
+            SET n += {
+                ref_type: row['ref_type']
+            }
+        } IN TRANSACTIONS OF 10000 ROWS
+        """) % split_edge_files["has_publication"].name.split("/")[-1]

--- a/tests/test_partial_ingestion.py
+++ b/tests/test_partial_ingestion.py
@@ -1,0 +1,391 @@
+import csv
+import gzip
+import tempfile
+from textwrap import dedent
+
+from indra_cogex.sources.partial_ingestion import (
+    read_file_headers,
+    _row_getter,
+    _set_expression,
+    format_set_clauses,
+    build_node_ingestion_query,
+    build_relationship_ingestion_query,
+    split_edge_file_by_type,
+)
+
+
+def test_read_file_headers():
+    with tempfile.NamedTemporaryFile(suffix=".tsv.gz") as temp_file:
+        with gzip.open(temp_file.name, "wt") as f:
+            csv_writer = csv.writer(f, delimiter="\t")
+            csv_writer.writerow(["header1","header2","header3"])
+
+        headers = read_file_headers(temp_file.name)
+        assert headers == ["header1", "header2", "header3"]
+
+
+def test_row_getter_plain():
+    get_str = _row_getter(header="prop")
+    assert get_str == "row['prop']", get_str
+
+
+def test_row_getter_dtype():
+    get_str = _row_getter("prop:int", dtype="int")
+    assert get_str == "toInteger(row['prop:int'])", get_str
+
+
+def test_row_getter_str_array():
+    header = "prop:string[]"
+    get_str = _row_getter(header)
+    assert get_str == (
+        f"CASE row['{header}'] WHEN '' THEN null ELSE split(row['{header}'], ';') END"
+    ), get_str
+
+
+def test_row_getter_bool_array():
+    # Note that 'bool' is not a Neo4j type for booleans, 'boolean' is
+    header = "prop:boolean[]"
+    get_str = _row_getter(header, dtype="boolean")
+    assert get_str == (
+        f"CASE row['{header}'] WHEN '' THEN null ELSE "
+        f"[x IN split(row['{header}'], ';') | toBoolean(x)] END"
+    ), get_str
+
+
+def test_set_expression_plain():
+    set_expr = _set_expression(header="prop")
+    assert set_expr == "prop: row['prop']", set_expr
+
+
+def test_set_expression_dtype():
+    set_expr = _set_expression(header="prop:int")
+    assert set_expr == "prop: toInteger(row['prop:int'])", set_expr
+
+
+def test_set_expression_str_array():
+    set_expr = _set_expression(header="prop:string[]")
+    assert set_expr == (
+        "prop: CASE row['prop:string[]'] WHEN '' THEN null ELSE "
+        "split(row['prop:string[]'], ';') END"
+    ), set_expr
+
+
+def test_set_expression_float_array():
+    set_expr = _set_expression(header="prop:float[]")
+    assert set_expr == (
+        "prop: CASE row['prop:float[]'] WHEN '' THEN null ELSE "
+        "[x IN split(row['prop:float[]'], ';') | toFloat(x)] END"
+    ), set_expr
+
+
+def test_set_expression_escape_dot():
+    set_expr = _set_expression(header="prop.name:float")
+    assert set_expr == "`prop.name`: toFloat(row['prop.name:float'])", set_expr
+
+
+def test_format_set_clauses():
+    property_headers = ["prop1", "prop2:int", "prop3:string[]", "prop4:boolean[]"]
+    query_set_clause = format_set_clauses(property_headers)
+    assert query_set_clause == """\
+        prop1: row['prop1'],
+        prop2: toInteger(row['prop2:int']),
+        prop3: CASE row['prop3:string[]'] WHEN '' THEN null ELSE split(row['prop3:string[]'], ';') END,
+        prop4: CASE row['prop4:boolean[]'] WHEN '' THEN null ELSE [x IN split(row['prop4:boolean[]'], ';') | toBoolean(x)] END"""
+
+
+def test_format_set_clauses_null():
+    query_set_clause = format_set_clauses([])
+    assert query_set_clause == ""
+
+
+def test_build_node_ingestion_query_import_anywhere():
+    with tempfile.NamedTemporaryFile(suffix=".tsv.gz") as temp_file:
+        with gzip.open(temp_file.name, "wt") as tsv_file:
+            csv_writer = csv.writer(tsv_file, delimiter="\t")
+            csv_writer.writerow(
+                [
+                    "id:ID",
+                    ":LABEL",
+                    "prop1",
+                    "prop2:int",
+                    "prop3:string[]",
+                    "prop4:boolean[]",
+                ]
+            )
+
+        headers = read_file_headers(temp_file.name)
+        query1 = build_node_ingestion_query(
+            label="TestNode",
+            file_path=temp_file.name,
+            headers=headers,
+            import_anywhere=True,
+        )
+        assert query1 == dedent("""\
+            LOAD CSV WITH HEADERS FROM 'file://%s' AS row
+            FIELDTERMINATOR '\\t'
+            CALL (row) {
+                MERGE (n:TestNode {id: row['id:ID']})
+                SET n += {
+                    prop1: row['prop1'],
+                    prop2: toInteger(row['prop2:int']),
+                    prop3: CASE row['prop3:string[]'] WHEN '' THEN null ELSE split(row['prop3:string[]'], ';') END,
+                    prop4: CASE row['prop4:boolean[]'] WHEN '' THEN null ELSE [x IN split(row['prop4:boolean[]'], ';') | toBoolean(x)] END
+                }
+            } IN TRANSACTIONS OF 10000 ROWS
+            """) % temp_file.name
+
+def test_build_node_ingestion_query_restricted_import():
+    with tempfile.NamedTemporaryFile(suffix=".tsv.gz") as temp_file:
+        with gzip.open(temp_file.name, "wt") as tsv_file:
+            csv_writer = csv.writer(tsv_file, delimiter="\t")
+            csv_writer.writerow(
+                [
+                    "id:ID",
+                    ":LABEL",
+                    "prop1",
+                    "prop2:int",
+                    "prop3:string[]",
+                    "prop4:boolean[]",
+                ]
+            )
+
+        headers = read_file_headers(temp_file.name)
+
+        query = build_node_ingestion_query(
+            label="TestNode",
+            file_path=temp_file.name,
+            headers=headers,
+            # Assumes file is in Neo4j import folder and file path is set
+            # relative to that folder
+            import_anywhere=False,
+        )
+        assert query == dedent("""\
+            LOAD CSV WITH HEADERS FROM 'file:///%s' AS row
+            FIELDTERMINATOR '\\t'
+            CALL (row) {
+                MERGE (n:TestNode {id: row['id:ID']})
+                SET n += {
+                    prop1: row['prop1'],
+                    prop2: toInteger(row['prop2:int']),
+                    prop3: CASE row['prop3:string[]'] WHEN '' THEN null ELSE split(row['prop3:string[]'], ';') END,
+                    prop4: CASE row['prop4:boolean[]'] WHEN '' THEN null ELSE [x IN split(row['prop4:boolean[]'], ';') | toBoolean(x)] END
+                }
+            } IN TRANSACTIONS OF 10000 ROWS
+            """) % temp_file.name.split('/')[-1]
+
+
+def test_build_relationship_ingestion_query_import_anywhere():
+    with tempfile.NamedTemporaryFile(suffix=".tsv.gz") as temp_file:
+        with gzip.open(temp_file.name, "wt") as tsv_file:
+            csv_writer = csv.writer(tsv_file, delimiter="\t")
+            csv_writer.writerow(
+                [
+                    ":START_ID",
+                    ":END_ID",
+                    ":TYPE",
+                    "prop1",
+                    "prop2:int",
+                    "prop3:string[]",
+                    "prop4:boolean[]",
+                ]
+            )
+
+        headers = read_file_headers(temp_file.name)
+        query = build_relationship_ingestion_query(
+            relationship_type="rel_type",
+            file_path=temp_file.name,
+            start_node_label="StartNode",
+            end_node_label="EndNode",
+            headers=headers,
+            import_anywhere=True,
+            parallel_edges=False,
+            parallel_properties=None,
+        )
+        assert query == dedent("""\
+            LOAD CSV WITH HEADERS FROM 'file://%s' AS row
+            FIELDTERMINATOR '\\t'
+            CALL (row) {
+                MATCH (a:StartNode {id: row[':START_ID']})
+                MATCH (b:EndNode {id: row[':END_ID']})
+                MERGE (a)-[n:rel_type]->(b)
+                SET n += {
+                    prop1: row['prop1'],
+                    prop2: toInteger(row['prop2:int']),
+                    prop3: CASE row['prop3:string[]'] WHEN '' THEN null ELSE split(row['prop3:string[]'], ';') END,
+                    prop4: CASE row['prop4:boolean[]'] WHEN '' THEN null ELSE [x IN split(row['prop4:boolean[]'], ';') | toBoolean(x)] END
+                }
+            } IN TRANSACTIONS OF 10000 ROWS
+            """) % temp_file.name
+
+
+def test_build_relationship_ingestion_query_restricted_import():
+    with tempfile.NamedTemporaryFile(suffix=".tsv.gz") as temp_file:
+        with gzip.open(temp_file.name, "wt") as tsv_file:
+            csv_writer = csv.writer(tsv_file, delimiter="\t")
+            csv_writer.writerow(
+                [
+                    ":START_ID",
+                    ":END_ID",
+                    ":TYPE",
+                    "prop1",
+                    "prop2:int",
+                    "prop3:string[]",
+                    "prop4:boolean[]",
+                ]
+            )
+
+        headers = read_file_headers(temp_file.name)
+        query = build_relationship_ingestion_query(
+            relationship_type="rel_type",
+            file_path=temp_file.name,
+            start_node_label="StartNode",
+            end_node_label="EndNode",
+            headers=headers,
+            import_anywhere=False,
+            parallel_edges=False,
+            parallel_properties=None,
+        )
+        assert query == dedent("""\
+            LOAD CSV WITH HEADERS FROM 'file:///%s' AS row
+            FIELDTERMINATOR '\\t'
+            CALL (row) {
+                MATCH (a:StartNode {id: row[':START_ID']})
+                MATCH (b:EndNode {id: row[':END_ID']})
+                MERGE (a)-[n:rel_type]->(b)
+                SET n += {
+                    prop1: row['prop1'],
+                    prop2: toInteger(row['prop2:int']),
+                    prop3: CASE row['prop3:string[]'] WHEN '' THEN null ELSE split(row['prop3:string[]'], ';') END,
+                    prop4: CASE row['prop4:boolean[]'] WHEN '' THEN null ELSE [x IN split(row['prop4:boolean[]'], ';') | toBoolean(x)] END
+                }
+            } IN TRANSACTIONS OF 10000 ROWS
+            """) % temp_file.name.split("/")[-1]
+
+
+def test_build_relationship_ingestion_query_parallel_edges():
+    with tempfile.NamedTemporaryFile(suffix=".tsv.gz") as temp_file:
+        with gzip.open(temp_file.name, "wt") as tsv_file:
+            csv_writer = csv.writer(tsv_file, delimiter="\t")
+            csv_writer.writerow(
+                [
+                    ":START_ID",
+                    ":END_ID",
+                    ":TYPE",
+                    "prop1",
+                    "prop2:int",
+                    "prop3:string[]",
+                    "prop4:boolean[]",
+                ]
+            )
+
+        headers = read_file_headers(temp_file.name)
+        query = build_relationship_ingestion_query(
+            relationship_type="rel_type",
+            file_path=temp_file.name,
+            start_node_label="StartNode",
+            end_node_label="EndNode",
+            headers=headers,
+            parallel_edges=True,
+            parallel_properties=None,
+        )
+        assert query == dedent("""\
+            LOAD CSV WITH HEADERS FROM 'file:///%s' AS row
+            FIELDTERMINATOR '\\t'
+            CALL (row) {
+                MATCH (a:StartNode {id: row[':START_ID']})
+                MATCH (b:EndNode {id: row[':END_ID']})
+                CREATE (a)-[n:rel_type]->(b)
+                SET n += {
+                    prop1: row['prop1'],
+                    prop2: toInteger(row['prop2:int']),
+                    prop3: CASE row['prop3:string[]'] WHEN '' THEN null ELSE split(row['prop3:string[]'], ';') END,
+                    prop4: CASE row['prop4:boolean[]'] WHEN '' THEN null ELSE [x IN split(row['prop4:boolean[]'], ';') | toBoolean(x)] END
+                }
+            } IN TRANSACTIONS OF 10000 ROWS
+            """) % temp_file.name.split("/")[-1]
+
+
+def test_build_relationship_ingestion_query_parallel_props():
+    with tempfile.NamedTemporaryFile(suffix=".tsv.gz") as temp_file:
+        with gzip.open(temp_file.name, "wt") as tsv_file:
+            csv_writer = csv.writer(tsv_file, delimiter="\t")
+            csv_writer.writerow(
+                [
+                    ":START_ID",
+                    ":END_ID",
+                    ":TYPE",
+                    "prop1",
+                    "prop2:int",
+                    "prop3:string[]",
+                    "prop4:boolean[]",
+                ]
+            )
+
+        headers = read_file_headers(temp_file.name)
+        query = build_relationship_ingestion_query(
+            relationship_type="rel_type",
+            file_path=temp_file.name,
+            start_node_label="StartNode",
+            end_node_label="EndNode",
+            headers=headers,
+            parallel_edges=True,
+            parallel_properties=["prop1"],
+        )
+        assert query == dedent("""\
+            LOAD CSV WITH HEADERS FROM 'file:///%s' AS row
+            FIELDTERMINATOR '\\t'
+            CALL (row) {
+                MATCH (a:StartNode {id: row[':START_ID']})
+                MATCH (b:EndNode {id: row[':END_ID']})
+                CREATE (a)-[n:rel_type {prop1: row['prop1']}]->(b)
+                SET n += {
+                    prop2: toInteger(row['prop2:int']),
+                    prop3: CASE row['prop3:string[]'] WHEN '' THEN null ELSE split(row['prop3:string[]'], ';') END,
+                    prop4: CASE row['prop4:boolean[]'] WHEN '' THEN null ELSE [x IN split(row['prop4:boolean[]'], ';') | toBoolean(x)] END
+                }
+            } IN TRANSACTIONS OF 10000 ROWS
+            """) % temp_file.name.split("/")[-1]
+
+
+def test_split_edge_file_by_type():
+    header = [
+        ":START_ID",
+        ":END_ID",
+        ":TYPE",
+        "prop1",
+        "prop2:int",
+        "prop3:string[]",
+        "prop4:boolean[]",
+    ]
+    with tempfile.NamedTemporaryFile(suffix=".tsv.gz") as temp_file:
+        with gzip.open(temp_file.name, "wt") as tsv_file:
+            csv_writer = csv.writer(tsv_file, delimiter="\t")
+            csv_writer.writerow(header)
+            csv_writer.writerow(["start1", "end1", "TYPE_A", "val1", "1", "a;b;c", "true;false"])
+            csv_writer.writerow(["start2", "end2", "TYPE_B", "val2", "2", "d;e;f", "false;true"])
+            csv_writer.writerow(["start3", "end3", "TYPE_A", "val3", "3", "g;h;i", "true;true"])
+        outfiles = split_edge_file_by_type(file_path=temp_file.name)
+        assert len(outfiles) == 2
+        assert {"TYPE_A", "TYPE_B"} == set(outfiles)
+
+        type_a_header = read_file_headers(outfiles["TYPE_A"])
+        assert type_a_header == header
+        type_b_header = read_file_headers(outfiles["TYPE_B"])
+        assert type_b_header == header
+
+        with gzip.open(outfiles["TYPE_A"], "rt") as f:
+            reader = csv.reader(f, delimiter="\t")
+            type_a_header = next(reader)
+            assert type_a_header == header
+            data_rows = list(reader)
+            assert len(data_rows) == 2
+            assert data_rows[0] == ["start1", "end1", "TYPE_A", "val1", "1", "a;b;c", "true;false"]
+            assert data_rows[1] == ["start3", "end3", "TYPE_A", "val3", "3", "g;h;i", "true;true"]
+
+        with gzip.open(outfiles["TYPE_B"], "rt") as f:
+            reader = csv.reader(f, delimiter="\t")
+            type_b_header = next(reader)
+            assert type_b_header == header
+            data_rows = list(reader)
+            assert len(data_rows) == 1
+            assert data_rows[0] == ["start2", "end2", "TYPE_B", "val2", "2", "d;e;f", "false;true"]

--- a/tests/test_partial_ingestion.py
+++ b/tests/test_partial_ingestion.py
@@ -532,6 +532,10 @@ def test_clinicaltrial_edges():
         assert {"tested_in", "has_trial", "has_publication"} == set(
             split_edge_files
         )
+        for rel_type, file_path in split_edge_files.items():
+            assert rel_type in file_path.name, \
+                f"File name {file_path.name} does not contain rel_type {rel_type}"
+
         tested_in_file_header = read_file_headers(split_edge_files["tested_in"])
         tested_in_file_header.remove("ref_type")
         tested_in_file_header.remove("source")

--- a/tests/test_partial_ingestion.py
+++ b/tests/test_partial_ingestion.py
@@ -203,7 +203,7 @@ def test_build_relationship_ingestion_query_import_anywhere():
             end_node_label="EndNode",
             headers=headers,
             import_anywhere=True,
-            parallel_edges=False,
+            write_mode="MERGE",
             parallel_properties=None,
         )
         assert query == dedent("""\
@@ -247,7 +247,7 @@ def test_build_relationship_ingestion_query_restricted_import():
             end_node_label="EndNode",
             headers=headers,
             import_anywhere=False,
-            parallel_edges=False,
+            write_mode="MERGE",
             parallel_properties=None,
         )
         assert query == dedent("""\
@@ -290,7 +290,7 @@ def test_build_relationship_ingestion_query_parallel_edges():
             start_node_label="StartNode",
             end_node_label="EndNode",
             headers=headers,
-            parallel_edges=True,
+            write_mode="CREATE",
             parallel_properties=None,
         )
         assert query == dedent("""\
@@ -333,7 +333,7 @@ def test_build_relationship_ingestion_query_parallel_props():
             start_node_label="StartNode",
             end_node_label="EndNode",
             headers=headers,
-            parallel_edges=True,
+            write_mode="CREATE",
             parallel_properties=["prop1"],
         )
         assert query == dedent("""\
@@ -546,7 +546,7 @@ def test_clinicaltrial_edges():
             end_node_label="ClinicalTrial",
             headers=tested_in_file_header,
             import_anywhere=False,
-            parallel_edges=False,
+            write_mode="MERGE",
             parallel_properties=None,
         )
         assert tested_in_query == dedent("""\
@@ -574,7 +574,7 @@ def test_clinicaltrial_edges():
             end_node_label="ClinicalTrial",
             headers=has_trial_file_header,
             import_anywhere=False,
-            parallel_edges=False,
+            write_mode="MERGE",
             parallel_properties=None,
         )
         assert has_trial_query == dedent("""\
@@ -601,7 +601,7 @@ def test_clinicaltrial_edges():
             end_node_label="Publication",
             headers=has_publication_file_header,
             import_anywhere=False,
-            parallel_edges=False,
+            write_mode="MERGE",
             parallel_properties=["source"],
         )
         assert has_publication_query == dedent("""\


### PR DESCRIPTION
This PR adds a module for a node and relationship ingestion API around Cypher's `LOAD CSV` command. The module docstring has links to relevant documentation as well as example queries. Tests are added for the new functions.

New methods are added to the `Neo4jClient` to delete nodes and relationships. Node and relationships are matched by labels and types, respectively, to narrow down which nodes and relations are deleted.