### PR TITLE
Landing page update

### DIFF
--- a/src/indra_cogex/apps/constants.py
+++ b/src/indra_cogex/apps/constants.py
@@ -46,6 +46,7 @@ edge_labels = {
     "variant_phenotype_association": "Variant Phenotype Associations",
     "has_activity": "Enzyme Annotations",
     "published_by": "Journal-Publisher Associations",
+    "codependent_with": "Gene knockout correlations",
 }
 
 INDRA_COGEX_WEB_LOCAL = (get_config("INDRA_COGEX_WEB_LOCAL") or "").lower() in {

--- a/src/indra_cogex/apps/constants.py
+++ b/src/indra_cogex/apps/constants.py
@@ -27,6 +27,7 @@ APPS_DIR = Path(__file__).parent.absolute()
 TEMPLATES_DIR = APPS_DIR / "templates"
 STATIC_DIR = APPS_DIR / "static"
 EDGE_COUNT_INFO_PATH = STATIC_DIR / "edge_count_info.json"
+NODE_COUNT_INFO_PATH = STATIC_DIR / "node_count_info.json"
 INDRA_COGEX_EXTENSION = "indra_cogex_client"
 STATEMENT_CURATION_CACHE = "curation_cache"
 SOURCE_BADGES_CSS = STATIC_DIR / "source_badges.css"
@@ -41,6 +42,15 @@ def load_edge_count_info() -> list[dict]:
 
 
 edge_count_info = load_edge_count_info()
+
+
+@lru_cache(1)
+def load_node_count_info() -> list[dict]:
+    with NODE_COUNT_INFO_PATH.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+node_count_info = load_node_count_info()
 
 
 # Set VUE parameters

--- a/src/indra_cogex/apps/constants.py
+++ b/src/indra_cogex/apps/constants.py
@@ -1,4 +1,6 @@
+import json
 import logging
+from functools import lru_cache
 from pathlib import Path
 from typing import Union
 
@@ -15,40 +17,6 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-edge_labels = {
-    "annotated_with": "MeSH Annotations",
-    "associated_with": "GO Annotations",
-    "has_citation": "Citations",
-    "indra_rel": "Causal Relations",
-    "expressed_in": "Gene Expressions",
-    "copy_number_altered_in": "CNVs",
-    "mutated_in": "Mutations",
-    "partof": "Part Of",
-    "has_trial": "Disease Trials",
-    "isa": "Subclasses",
-    "haspart": "Has Part",
-    "has_side_effect": "Side Effects",
-    "tested_in": "Drug Trials",
-    "sensitive_to": "Sensitivities",
-    "has_indication": "Drug Indications",
-    "has_phenotype": "Disease Phenotypes",
-    "phenotype_has_gene": "Phenotype Genes",
-    "has_publication": "Project Publications",
-    "has_clinical_trial": "Project Trials",
-    "has_patent": "Project Patents",
-    "has_marker": "Cell Markers",
-    "has_domain": "Protein Domains",
-    "gene_disease_association": "Gene Disease Associations",
-    # Links Publications to Journals
-    "published_in": "Journal Associations",
-    "variant_disease_association": "Variant Disease Associations",
-    "variant_gene_association": "Variant Gene Associations",
-    "variant_phenotype_association": "Variant Phenotype Associations",
-    "has_activity": "Enzyme Annotations",
-    "published_by": "Journal-Publisher Associations",
-    "codependent_with": "Gene knockout correlations",
-}
-
 INDRA_COGEX_WEB_LOCAL = (get_config("INDRA_COGEX_WEB_LOCAL") or "").lower() in {
     "t",
     "true",
@@ -58,11 +26,22 @@ APP_CACHE_MODULE = pystow.module("indra", "cogex", "app_cache")
 APPS_DIR = Path(__file__).parent.absolute()
 TEMPLATES_DIR = APPS_DIR / "templates"
 STATIC_DIR = APPS_DIR / "static"
+EDGE_COUNT_INFO_PATH = STATIC_DIR / "edge_count_info.json"
 INDRA_COGEX_EXTENSION = "indra_cogex_client"
 STATEMENT_CURATION_CACHE = "curation_cache"
 SOURCE_BADGES_CSS = STATIC_DIR / "source_badges.css"
 AGENT_NAME_CACHE = APP_CACHE_MODULE.join(name="search_agent_cache.pkl")
 GUNICORN_CONFIG = APPS_DIR / "gunicorn.conf.py"
+
+
+@lru_cache(1)
+def load_edge_count_info() -> list[dict]:
+    with EDGE_COUNT_INFO_PATH.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+edge_count_info = load_edge_count_info()
+
 
 # Set VUE parameters
 sources_dict = {

--- a/src/indra_cogex/apps/home/__init__.py
+++ b/src/indra_cogex/apps/home/__init__.py
@@ -3,7 +3,7 @@ from typing import Counter, Tuple
 
 from flask import Blueprint, current_app, render_template
 
-from indra_cogex.apps.constants import edge_count_info, pusher_key
+from indra_cogex.apps.constants import edge_count_info, node_count_info, pusher_key
 from indra_cogex.apps.proxies import client
 
 from ...client.queries import get_curated_edge_counter, get_node_counter
@@ -43,6 +43,8 @@ def _figure_number(n: int):
 def home():
     """Render the home page."""
     node_counter, edge_counter = _get_counters()
+    total_nodes = sum(node_counter.values())
+    total_edges = sum(edge_counter.values())
     edge_specs_sorted = sorted(
         edge_count_info,
         key=lambda spec: edge_counter[spec.get("key", spec["rel_type"])],
@@ -53,7 +55,10 @@ def home():
         format_number=_figure_number,
         node_counter=node_counter,
         edge_counter=edge_counter,
+        total_nodes=total_nodes,
+        total_edges=total_edges,
         edge_specs_sorted=edge_specs_sorted,
+        node_count_info=node_count_info,
         blueprints=current_app.blueprints,
         pusher_app_key=pusher_key,
     )

--- a/src/indra_cogex/apps/home/__init__.py
+++ b/src/indra_cogex/apps/home/__init__.py
@@ -3,10 +3,10 @@ from typing import Counter, Tuple
 
 from flask import Blueprint, current_app, render_template
 
-from indra_cogex.apps.constants import edge_labels, pusher_key
+from indra_cogex.apps.constants import edge_count_info, pusher_key
 from indra_cogex.apps.proxies import client
 
-from ...client.queries import get_edge_counter, get_node_counter
+from ...client.queries import get_curated_edge_counter, get_node_counter
 
 __all__ = [
     "home_blueprint",
@@ -18,7 +18,7 @@ home_blueprint = Blueprint("home", __name__)
 @lru_cache(1)
 def _get_counters() -> Tuple[Counter, Counter]:
     node_counter = get_node_counter(client=client)
-    edge_counter = get_edge_counter(client=client)
+    edge_counter = get_curated_edge_counter(edge_count_info, client=client)
     return node_counter, edge_counter
 
 
@@ -43,14 +43,17 @@ def _figure_number(n: int):
 def home():
     """Render the home page."""
     node_counter, edge_counter = _get_counters()
-    ignore_labels = ["replaced_by", "xref"]
+    edge_specs_sorted = sorted(
+        edge_count_info,
+        key=lambda spec: edge_counter[spec.get("key", spec["rel_type"])],
+        reverse=True,
+    )
     return render_template(
         "home.html",
         format_number=_figure_number,
         node_counter=node_counter,
         edge_counter=edge_counter,
-        ignore_labels=ignore_labels,
-        edge_labels=edge_labels,
+        edge_specs_sorted=edge_specs_sorted,
         blueprints=current_app.blueprints,
         pusher_app_key=pusher_key,
     )

--- a/src/indra_cogex/apps/queries_web/__init__.py
+++ b/src/indra_cogex/apps/queries_web/__init__.py
@@ -531,12 +531,23 @@ SKIP_ARGUMENTS = {
     "get_statements": {"mesh_term", "include_child_terms"}
 }
 
+# Functions to ignore from specific modules
+SKIP_FUNCTIONS = {
+    "queries": [
+        "get_node_counter",
+        "get_edge_counter",
+        "count_edges",
+        "get_curated_edge_counter",
+        "get_schema_graph",
+    ]
+}
+
 # This is the list of functions to be included
 # To add a new function, make sure it is part of __all__ in the respective module or is
 # listed explicitly below and properly documented in its docstring as well as having
 # example values for its parameters in the examples_dict above.
 module_functions = (
-    [(queries, fn) for fn in queries.__all__] +
+    [(queries, fn) for fn in queries.__all__ if fn not in SKIP_FUNCTIONS["queries"]] +
     [(subnetwork, fn) for fn in [
         "indra_subnetwork_relations",
         "indra_subnetwork_meta",

--- a/src/indra_cogex/apps/queries_web/__init__.py
+++ b/src/indra_cogex/apps/queries_web/__init__.py
@@ -531,23 +531,12 @@ SKIP_ARGUMENTS = {
     "get_statements": {"mesh_term", "include_child_terms"}
 }
 
-# Functions to ignore from specific modules
-SKIP_FUNCTIONS = {
-    "queries": [
-        "get_node_counter",
-        "get_edge_counter",
-        "count_edges",
-        "get_curated_edge_counter",
-        "get_schema_graph",
-    ]
-}
-
 # This is the list of functions to be included
 # To add a new function, make sure it is part of __all__ in the respective module or is
 # listed explicitly below and properly documented in its docstring as well as having
 # example values for its parameters in the examples_dict above.
 module_functions = (
-    [(queries, fn) for fn in queries.__all__ if fn not in SKIP_FUNCTIONS["queries"]] +
+    [(queries, fn) for fn in queries.__all__] +
     [(subnetwork, fn) for fn in [
         "indra_subnetwork_relations",
         "indra_subnetwork_meta",

--- a/src/indra_cogex/apps/static/edge_count_info.json
+++ b/src/indra_cogex/apps/static/edge_count_info.json
@@ -40,7 +40,7 @@
     "info": "Gene complex membership<br>Source: INDRA BioOntology"
   },
   {
-    "rel_type": "has_condition",
+    "rel_type": "has_trial",
     "label": "Disease Trials",
     "info": "Condition treated in clinical trial<br>Source: clinicaltrials.gov"
   },
@@ -60,7 +60,7 @@
     "info": "Drug side effects<br>Source: sideeffects.embl.de"
   },
   {
-    "rel_type": "has_intervention",
+    "rel_type": "tested_in",
     "label": "Drug Trials",
     "info": "Drug (and other interventions) tested in clinical trial<br>Source: clinicaltrials.gov"
   },

--- a/src/indra_cogex/apps/static/edge_count_info.json
+++ b/src/indra_cogex/apps/static/edge_count_info.json
@@ -2,87 +2,87 @@
   {
     "rel_type": "annotated_with",
     "label": "MeSH Annotations",
-    "info": "...text..."
+    "info": "Article MeSH annotations<br>Source: ncbi.nlm.nih.gov"
   },
   {
     "rel_type": "associated_with",
     "label": "GO Annotations",
-    "info": "..."
+    "info": "Gene Ontology (GO) annotations<br>Sources: geneontology.org and www.ebi.ac.uk/interpro/"
   },
   {
     "rel_type": "has_citation",
     "label": "Citations",
-    "info": "..."
+    "info": "INDRA Evidence linked to a publication<br>Source: INDRA"
   },
   {
     "rel_type": "indra_rel",
     "label": "Causal Relations",
-    "info": "..."
+    "info": "Casual relations extracted by INDRA as Statements<br>Source: INDRA"
   },
   {
     "rel_type": "expressed_in",
     "label": "Gene Expressions",
-    "info": "..."
+    "info": "Gene Expression data connecting genes with tissues and organs they are expressed in<br>Source: bgee.org"
   },
   {
     "rel_type": "copy_number_altered_in",
     "label": "CNVs",
-    "info": "..."
+    "info": "Gene copy number alteration in cell lines<br>Source: cbioportal.org"
   },
   {
     "rel_type": "mutated_in",
     "label": "Mutations",
-    "info": "..."
+    "info": "Gene mutation in cell lines<br>Source: cbioportal.org"
   },
   {
     "rel_type": "partof",
     "label": "Part Of",
-    "info": "..."
+    "info": "Gene complex membership<br>Source: INDRA BioOntology"
   },
   {
     "rel_type": "has_condition",
     "label": "Disease Trials",
-    "info": "..."
+    "info": "Condition treated in clinical trial<br>Source: clinicaltrials.gov"
   },
   {
     "rel_type": "isa",
     "label": "Subclasses",
-    "info": "..."
+    "info": "Gene family membership<br>Source: INDRA BioOntology"
   },
   {
     "rel_type": "haspart",
-    "label": "Has Part",
-    "info": "..."
+    "label": "Gene-pathway associations",
+    "info": "Genetic pathway memberships<br>Source: INDRA BioOntology"
   },
   {
     "rel_type": "has_side_effect",
     "label": "Side Effects",
-    "info": "..."
+    "info": "Drug side effects<br>Source: sideeffects.embl.de"
   },
   {
     "rel_type": "has_intervention",
     "label": "Drug Trials",
-    "info": "..."
+    "info": "Drug (and other interventions) tested in clinical trial<br>Source: clinicaltrials.gov"
   },
   {
     "rel_type": "sensitive_to",
     "label": "Sensitivities",
-    "info": "..."
+    "info": "Cell line drug sensitivity<br>Source: cbioportal.org"
   },
   {
     "rel_type": "has_indication",
     "label": "Drug Indications",
-    "info": "..."
+    "info": "Drug indications<br>Source: www.ebi.ac.uk/chembl"
   },
   {
     "rel_type": "has_phenotype",
     "label": "Disease Phenotypes",
-    "info": "..."
+    "info": "Disease phenotype annotations<br>Source: hpo.jax.org"
   },
   {
     "rel_type": "phenotype_has_gene",
     "label": "Phenotype Genes",
-    "info": "..."
+    "info": "Phenotype-gene annotations<br>Source: hpo.jax.org"
   },
   {
     "key": "project_publications",
@@ -90,7 +90,7 @@
     "source_label": "ResearchProject",
     "target_label": "Publication",
     "label": "Project Publications",
-    "info": "..."
+    "info": "Publications of NIH research project with project numbers<br>Source: reporter.nih.gov/exporter/"
   },
   {
     "key": "trial_publications",
@@ -98,116 +98,111 @@
     "source_label": "ClinicalTrial",
     "target_label": "Publication",
     "label": "Trial Publications",
-    "info": "..."
+    "info": "Publications related to clinical trials<br>Sources: clinicaltrials.gov and ncbi.nlm.nih.gov"
   },
   {
     "rel_type": "has_clinical_trial",
     "label": "Project Trials",
-    "info": "..."
+    "info": "Clinical trial associated with an NIH research project<br>Source: reporter.nih.gov/exporter/"
   },
   {
     "rel_type": "has_patent",
     "label": "Project Patents",
-    "info": "..."
+    "info": "Patent associated with an NIH research project<br>Source: reporter.nih.gov/exporter/"
   },
   {
     "rel_type": "has_marker",
     "label": "Cell Markers",
-    "info": "..."
+    "info": "Cell marker - gene associations<br>Source: xteam.xbio.top"
   },
   {
     "rel_type": "has_domain",
     "label": "Protein Domains",
-    "info": "..."
+    "info": "Gene - protein domain association<br>Source: www.ebi.ac.uk/interpro/"
   },
   {
     "rel_type": "gene_disease_association",
     "label": "Gene Disease Associations",
-    "info": "..."
+    "info": "Gene association with disease<br>Source: www.disgenet.org"
   },
   {
     "rel_type": "published_in",
     "label": "Journal Associations",
-    "info": "..."
+    "info": "Journal used for publication<br>Source: ncbi.nlm.nih.gov"
   },
   {
     "rel_type": "variant_disease_association",
     "label": "Variant Disease Associations",
-    "info": "..."
+    "info": "Genetic variant association with disease <br>Source: www.disgenet.org"
   },
   {
     "rel_type": "variant_gene_association",
     "label": "Variant Gene Associations",
-    "info": "..."
+    "info": "Genetic variant - gene association<br>Source: www.ebi.ac.uk/gwas"
   },
   {
     "rel_type": "variant_phenotype_association",
     "label": "Variant Phenotype Associations",
-    "info": "..."
+    "info": "Genetic variant - phenotype association<br>Source: www.ebi.ac.uk/gwas"
   },
   {
     "rel_type": "has_activity",
     "label": "Enzyme Annotations",
-    "info": "..."
+    "info": "Gene - enzyme annotation<br>Source: www.genenames.org"
   },
   {
     "rel_type": "published_by",
     "label": "Journal-Publisher Associations",
-    "info": "..."
+    "info": "Journals by publisher<br>Source: www.wikidata.org"
   },
   {
     "rel_type": "has_trial_result",
     "label": "Trial Results",
-    "info": "..."
+    "info": "Clinical trial results<br>Source: clinicaltrials.gov"
   },
   {
     "rel_type": "has_arm",
     "label": "Trial Arms",
-    "info": "..."
+    "info": "Clinical trial study arms<br>Source: clinicaltrials.gov"
   },
   {
     "rel_type": "has_metric",
     "label": "Trial Metrics",
-    "info": "..."
+    "info": "Clinical trial arm metric<br>Source: clinicaltrials.gov"
   },
   {
     "rel_type": "has_adverse_event",
     "label": "Trial Adverse Events",
-    "info": "..."
+    "info": "Clinical trial arm adverse event measurement<br>Source: clinicaltrials.gov"
   },
   {
     "rel_type": "has_inclusion_criterion",
     "label": "Trial Inclusion Criteria",
-    "info": "..."
+    "info": "Criteria for inclusion in a clinical trial<br>Source: clinicaltrials.gov"
   },
   {
     "rel_type": "has_exclusion_criterion",
     "label": "Trial Exclusion Criteria",
-    "info": "..."
+    "info": "Criteria for exclusion from the trial<br>Source: clinicaltrials.gov"
   },
   {
     "rel_type": "has_outcome",
     "label": "Trial Outcomes",
-    "info": "..."
+    "info": "Clinical trial outcome<br>Source: clinicaltrials.gov"
   },
   {
     "rel_type": "has_statistical_comparison",
     "label": "Trial Arm Comparisons",
-    "info": "..."
+    "info": "Clinical trial arms comparisons<br>Source: clinicaltrials.gov"
   },
   {
     "rel_type": "has_genetic_criterion",
     "label": "Trial Genetic Eligibility",
-    "info": "..."
-  },
-  {
-    "rel_type": "has_trial_source",
-    "label": "Trial Source",
-    "info": "..."
+    "info": "Genetic biomarker in clinical trial<br>Source: clinicaltrials.gov"
   },
   {
     "rel_type": "codependent_with",
     "label": "Gene Knockout Correlations",
-    "info": "..."
+    "info": "Gene-gene correlations in knockout experiments<br>Source: depmap.org"
   }
 ]

--- a/src/indra_cogex/apps/static/edge_count_info.json
+++ b/src/indra_cogex/apps/static/edge_count_info.json
@@ -1,0 +1,213 @@
+[
+  {
+    "rel_type": "annotated_with",
+    "label": "MeSH Annotations",
+    "info": "...text..."
+  },
+  {
+    "rel_type": "associated_with",
+    "label": "GO Annotations",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_citation",
+    "label": "Citations",
+    "info": "..."
+  },
+  {
+    "rel_type": "indra_rel",
+    "label": "Causal Relations",
+    "info": "..."
+  },
+  {
+    "rel_type": "expressed_in",
+    "label": "Gene Expressions",
+    "info": "..."
+  },
+  {
+    "rel_type": "copy_number_altered_in",
+    "label": "CNVs",
+    "info": "..."
+  },
+  {
+    "rel_type": "mutated_in",
+    "label": "Mutations",
+    "info": "..."
+  },
+  {
+    "rel_type": "partof",
+    "label": "Part Of",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_condition",
+    "label": "Disease Trials",
+    "info": "..."
+  },
+  {
+    "rel_type": "isa",
+    "label": "Subclasses",
+    "info": "..."
+  },
+  {
+    "rel_type": "haspart",
+    "label": "Has Part",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_side_effect",
+    "label": "Side Effects",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_intervention",
+    "label": "Drug Trials",
+    "info": "..."
+  },
+  {
+    "rel_type": "sensitive_to",
+    "label": "Sensitivities",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_indication",
+    "label": "Drug Indications",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_phenotype",
+    "label": "Disease Phenotypes",
+    "info": "..."
+  },
+  {
+    "rel_type": "phenotype_has_gene",
+    "label": "Phenotype Genes",
+    "info": "..."
+  },
+  {
+    "key": "project_publications",
+    "rel_type": "has_publication",
+    "source_label": "ResearchProject",
+    "target_label": "Publication",
+    "label": "Project Publications",
+    "info": "..."
+  },
+  {
+    "key": "trial_publications",
+    "rel_type": "has_publication",
+    "source_label": "ClinicalTrial",
+    "target_label": "Publication",
+    "label": "Trial Publications",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_clinical_trial",
+    "label": "Project Trials",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_patent",
+    "label": "Project Patents",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_marker",
+    "label": "Cell Markers",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_domain",
+    "label": "Protein Domains",
+    "info": "..."
+  },
+  {
+    "rel_type": "gene_disease_association",
+    "label": "Gene Disease Associations",
+    "info": "..."
+  },
+  {
+    "rel_type": "published_in",
+    "label": "Journal Associations",
+    "info": "..."
+  },
+  {
+    "rel_type": "variant_disease_association",
+    "label": "Variant Disease Associations",
+    "info": "..."
+  },
+  {
+    "rel_type": "variant_gene_association",
+    "label": "Variant Gene Associations",
+    "info": "..."
+  },
+  {
+    "rel_type": "variant_phenotype_association",
+    "label": "Variant Phenotype Associations",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_activity",
+    "label": "Enzyme Annotations",
+    "info": "..."
+  },
+  {
+    "rel_type": "published_by",
+    "label": "Journal-Publisher Associations",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_trial_result",
+    "label": "Trial Results",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_arm",
+    "label": "Trial Arms",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_metric",
+    "label": "Trial Metrics",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_adverse_event",
+    "label": "Trial Adverse Events",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_inclusion_criterion",
+    "label": "Trial Inclusion Criteria",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_exclusion_criterion",
+    "label": "Trial Exclusion Criteria",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_outcome",
+    "label": "Trial Outcomes",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_statistical_comparison",
+    "label": "Trial Arm Comparisons",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_genetic_criterion",
+    "label": "Trial Genetic Eligibility",
+    "info": "..."
+  },
+  {
+    "rel_type": "has_trial_source",
+    "label": "Trial Source",
+    "info": "..."
+  },
+  {
+    "rel_type": "codependent_with",
+    "label": "Gene Knockout Correlations",
+    "info": "..."
+  }
+]

--- a/src/indra_cogex/apps/static/node_count_info.json
+++ b/src/indra_cogex/apps/static/node_count_info.json
@@ -1,0 +1,56 @@
+[
+  {
+    "node_label": "BioEntity",
+    "label": "Biological Entities",
+    "icon": "dna",
+    "info": "Placeholder description for biological entities."
+  },
+  {
+    "node_label": "ClinicalTrial",
+    "label": "Clinical Trials",
+    "icon": "clinic-medical",
+    "info": "Placeholder description for clinical trials."
+  },
+  {
+    "node_label": "Publication",
+    "label": "Publications",
+    "icon": "book",
+    "info": "Placeholder description for publications."
+  },
+  {
+    "node_label": "Evidence",
+    "label": "Evidences",
+    "icon": "puzzle-piece",
+    "info": "Placeholder description for evidences."
+  },
+  {
+    "node_label": "ResearchProject",
+    "label": "Research Projects",
+    "icon": "flask",
+    "info": "Placeholder description for research projects."
+  },
+  {
+    "node_label": "Patent",
+    "label": "Patents",
+    "icon": "copyright",
+    "info": "Placeholder description for patents."
+  },
+  {
+    "node_label": "Journal",
+    "label": "Journals",
+    "icon": "newspaper",
+    "info": "Placeholder description for journals."
+  },
+  {
+    "node_label": "Publisher",
+    "label": "Publishers",
+    "icon": "building",
+    "info": "Placeholder description for publishers."
+  },
+  {
+    "node_label": "TrialResult",
+    "label": "Trial Results",
+    "icon": "clipboard-check",
+    "info": "Placeholder description for trial results."
+  }
+]

--- a/src/indra_cogex/apps/static/node_count_info.json
+++ b/src/indra_cogex/apps/static/node_count_info.json
@@ -3,54 +3,54 @@
     "node_label": "BioEntity",
     "label": "Biological Entities",
     "icon": "dna",
-    "info": "Placeholder description for biological entities."
+    "info": "Identified genes, proteins, small molecules, tissues, medical conditions and other biomedically relevant entitites"
   },
   {
     "node_label": "ClinicalTrial",
     "label": "Clinical Trials",
     "icon": "clinic-medical",
-    "info": "Placeholder description for clinical trials."
+    "info": "Clinical trials and their meta data from clinicaltrials.gov"
   },
   {
     "node_label": "Publication",
     "label": "Publications",
     "icon": "book",
-    "info": "Placeholder description for publications."
+    "info": "Publications registered on PubMed"
   },
   {
     "node_label": "Evidence",
     "label": "Evidences",
     "icon": "puzzle-piece",
-    "info": "Placeholder description for evidences."
+    "info": "INDRA Statement Evidences"
   },
   {
     "node_label": "ResearchProject",
     "label": "Research Projects",
     "icon": "flask",
-    "info": "Placeholder description for research projects."
+    "info": "NIH registered research projects"
   },
   {
     "node_label": "Patent",
     "label": "Patents",
     "icon": "copyright",
-    "info": "Placeholder description for patents."
+    "info": "Patents associated with NIH research projects"
   },
   {
     "node_label": "Journal",
     "label": "Journals",
     "icon": "newspaper",
-    "info": "Placeholder description for journals."
+    "info": "Scientific journals"
   },
   {
     "node_label": "Publisher",
     "label": "Publishers",
     "icon": "building",
-    "info": "Placeholder description for publishers."
+    "info": "Publishers of scientific journals"
   },
   {
     "node_label": "TrialResult",
     "label": "Trial Results",
     "icon": "clipboard-check",
-    "info": "Placeholder description for trial results."
+    "info": "LLM extracted clinical trial results from publications"
   }
 ]

--- a/src/indra_cogex/apps/templates/base.html
+++ b/src/indra_cogex/apps/templates/base.html
@@ -29,7 +29,7 @@
             </style>
         {% endblock %}
 
-        <script src="https://kit.fontawesome.com/4c86883252.js" crossorigin="anonymous"></script>
+        <script src="https://kit.fontawesome.com/97b4a2bc36.js" crossorigin="anonymous"></script>
         <title>{% block title %}{% endblock %}</title>
     {% endblock %}
 </head>

--- a/src/indra_cogex/apps/templates/home.html
+++ b/src/indra_cogex/apps/templates/home.html
@@ -151,7 +151,7 @@
 {% block container %}
     <div class="row">
         <div class="card card-body" style="margin-bottom: 0.8em;">
-            <h1 class="display-5">INDRA Biomedical Discovery Engine</h1>
+            <h1 class="display-5 text-center">INDRA Biomedical Discovery Engine</h1>
             <p class="lead text-justify">
                 The INDRA Biomedical Discovery Engine is built on INDRA CoGEx, a graph database integrating causal
                 relations, ontological relations, properties, and data, assembled at scale automatically from the

--- a/src/indra_cogex/apps/templates/home.html
+++ b/src/indra_cogex/apps/templates/home.html
@@ -44,35 +44,96 @@
         .stats-summary[aria-expanded="true"] .stats-chevron {
             transform: rotate(180deg);
         }
+
+        #graph-stats-details .stats-breakdown-section {
+            padding-top: 0.5rem;
+            margin-top: 0.5rem;
+            border-top: 1px solid rgba(0, 0, 0, .12);
+        }
+
+        #graph-stats-details .stats-breakdown-section:first-child {
+            padding-top: 0.5rem;
+            margin-top: 0.5rem;
+        }
+
+        #graph-stats-details .stats-breakdown-heading {
+            font-size: 0.85rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: #6c757d;
+            margin-bottom: 0.25rem;
+            text-align: center;
+        }
+
+        #graph-stats-details .stats-breakdown-row {
+            display: flex;
+            flex-wrap: nowrap;
+            justify-content: center;
+            text-align: center;
+            margin-bottom: 0.4rem;
+        }
+
+        #graph-stats-details .stats-breakdown-row:last-child {
+            margin-bottom: 0;
+        }
+
+        #graph-stats-details .stats-breakdown-row--nodes .stats-breakdown-item {
+            flex: 0 0 calc(100% / 9);
+            max-width: calc(100% / 9);
+            min-width: 0;
+        }
+
+        @media (max-width: 768px) {
+            #graph-stats-details .stats-breakdown-row--nodes {
+                flex-wrap: wrap;
+            }
+
+            #graph-stats-details .stats-breakdown-row--nodes .stats-breakdown-item {
+                flex: 0 0 calc(100% / 3);
+                max-width: calc(100% / 3);
+            }
+        }
+
+        #graph-stats-details .stats-breakdown-row--edges .stats-breakdown-item {
+            flex: 0 0 calc(100% / 8);
+            max-width: calc(100% / 8);
+            min-width: 0;
+        }
+
+        #graph-stats-details .stats-breakdown-item > .col {
+            flex: none;
+            max-width: 100%;
+            width: 100%;
+            padding-left: 0.2rem;
+            padding-right: 0.2rem;
+            margin-bottom: 0.25rem;
+            font-size: 0.9rem;
+            line-height: 1.2;
+        }
+
+        #graph-stats-details .stats-breakdown-item small {
+            font-size: 0.75rem;
+            line-height: 1.15;
+        }
     </style>
 {% endblock %}
 
-{% macro count_column(counter, key, label, icon, info=None) -%}
+{% macro count_column_small(counter, key, label, info=None, icon=None) -%}
     <div class="col"
          {% if info %}
          data-toggle="tooltip"
          data-placement="top"
          title="{{ info }}"
          {% endif %}>
-        {% set count, suffix = format_number(counter[key]) %}
-        <i class="fa fa-{{ icon }}"></i>
-        <h2><span class="count-{{ key }}" data-to="{{ count }}" data-time="1000"></span>{{ suffix }}</h2>
-        <p class="count-text ">{{ label }}</p>
-    </div>
-{% endmacro %}
-
-{% macro count_column_small(counter, key, label, info=None) -%}
-    <div class="col" style="margin-bottom: 1em"
-         {% if info %}
-         data-toggle="tooltip"
-         data-placement="top"
-         title="{{ info }}"
-         {% endif %}>
+        {% if icon %}
+            <i class="fa fa-{{ icon }} fa-sm"></i><br/>
+        {% endif %}
         {% set count, suffix = format_number(counter[key]) %}
         <span class="count-{{ key }}" data-to="{{ count }}" data-time="1000"></span>{{ suffix }}<br/>
         <small>
             {% if label %}
-                {{ label|replace(" ", "&nbsp;")|safe }}
+                {{ label }}
             {% else %}
                 {{ key }}
             {% endif %}
@@ -121,15 +182,29 @@
                 </div>
             </div>
             <div class="collapse" id="graph-stats-details">
-                <div class="row text-center stats">
-                    {% for spec in node_count_info %}
-                        {{ count_column(node_counter, spec["node_label"], spec["label"], spec["icon"], spec.get("info", "")) }}
+                <div class="stats-breakdown-section">
+                    <h5 class="stats-breakdown-heading">Nodes</h5>
+                    {% for row in node_count_info|batch(9) %}
+                        <div class="stats-breakdown-row stats-breakdown-row--nodes stats">
+                            {% for spec in row %}
+                                <div class="stats-breakdown-item">
+                                    {{ count_column_small(node_counter, spec["node_label"], spec["label"], spec.get("info", ""), spec["icon"]) }}
+                                </div>
+                            {% endfor %}
+                        </div>
                     {% endfor %}
                 </div>
-                <div class="row text-center stats" style="padding-left: 3em; padding-right: 3em;">
-                    {% for spec in edge_specs_sorted %}
-                        {% set key = spec["key"] if "key" in spec else spec["rel_type"] %}
-                        {{ count_column_small(edge_counter, key, spec["label"], spec.get("info", "")) }}
+                <div class="stats-breakdown-section">
+                    <h5 class="stats-breakdown-heading">Edges</h5>
+                    {% for row in edge_specs_sorted|batch(8) %}
+                        <div class="stats-breakdown-row stats-breakdown-row--edges stats">
+                            {% for spec in row %}
+                                {% set key = spec["key"] if "key" in spec else spec["rel_type"] %}
+                                <div class="stats-breakdown-item">
+                                    {{ count_column_small(edge_counter, key, spec["label"], spec.get("info", "")) }}
+                                </div>
+                            {% endfor %}
+                        </div>
                     {% endfor %}
                 </div>
             </div>

--- a/src/indra_cogex/apps/templates/home.html
+++ b/src/indra_cogex/apps/templates/home.html
@@ -76,10 +76,9 @@
                 {{ count_column(node_counter, "Patent", "Patents", "copyright") }}
             </div>
             <div class="row text-center stats" style="padding-left: 3em; padding-right: 3em;">
-                {% for edge_type, _ in edge_counter.most_common() %}
-                    {% if edge_type not in ignore_labels %}
-                        {{ count_column_small(edge_counter, edge_type, edge_labels[edge_type]) }}
-                    {% endif %}
+                {% for spec in edge_specs_sorted %}
+                    {% set key = spec["key"] if "key" in spec else spec["rel_type"] %}
+                    {{ count_column_small(edge_counter, key, spec["label"]) }}
                 {% endfor %}
             </div>
         </div>
@@ -414,7 +413,8 @@
             {% for key in node_counter %}
                 $('.count-{{ key }}').counter();
             {% endfor %}
-            {% for key in edge_counter %}
+            {% for spec in edge_specs_sorted %}
+                {% set key = spec["key"] if "key" in spec else spec["rel_type"] %}
                 $('.count-{{ key }}').counter();
             {% endfor %}
         });

--- a/src/indra_cogex/apps/templates/home.html
+++ b/src/indra_cogex/apps/templates/home.html
@@ -150,8 +150,8 @@
 {% block container %}
     <div class="row">
         <div class="card card-body" style="margin-bottom: 0.8em;">
-            <h1 class="display-4">INDRA Biomedical Discovery Engine</h1>
-            <p class="lead">
+            <h1 class="display-5">INDRA Biomedical Discovery Engine</h1>
+            <p class="lead text-justify">
                 The INDRA Biomedical Discovery Engine is built on INDRA CoGEx, a graph database integrating causal
                 relations, ontological relations, properties, and data, assembled at scale automatically from the
                 scientific literature and structured sources.

--- a/src/indra_cogex/apps/templates/home.html
+++ b/src/indra_cogex/apps/templates/home.html
@@ -26,11 +26,34 @@
         #home-decks > h3 {
             margin: 0.5em auto 1em; /* Reduced margins for section headers */
         }
+
+        .stats-summary {
+            cursor: pointer;
+            padding-top: 0.5em;
+            padding-bottom: 0.5em;
+        }
+
+        .stats-summary:hover {
+            background-color: rgba(0, 0, 0, .03);
+        }
+
+        .stats-chevron {
+            transition: transform .2s ease;
+        }
+
+        .stats-summary[aria-expanded="true"] .stats-chevron {
+            transform: rotate(180deg);
+        }
     </style>
 {% endblock %}
 
-{% macro count_column(counter, key, label, icon) -%}
-    <div class="col">
+{% macro count_column(counter, key, label, icon, info=None) -%}
+    <div class="col"
+         {% if info %}
+         data-toggle="tooltip"
+         data-placement="top"
+         title="{{ info }}"
+         {% endif %}>
         {% set count, suffix = format_number(counter[key]) %}
         <i class="fa fa-{{ icon }}"></i>
         <h2><span class="count-{{ key }}" data-to="{{ count }}" data-time="1000"></span>{{ suffix }}</h2>
@@ -38,8 +61,13 @@
     </div>
 {% endmacro %}
 
-{% macro count_column_small(counter, key, label) -%}
-    <div class="col" style="margin-bottom: 1em">
+{% macro count_column_small(counter, key, label, info=None) -%}
+    <div class="col" style="margin-bottom: 1em"
+         {% if info %}
+         data-toggle="tooltip"
+         data-placement="top"
+         title="{{ info }}"
+         {% endif %}>
         {% set count, suffix = format_number(counter[key]) %}
         <span class="count-{{ key }}" data-to="{{ count }}" data-time="1000"></span>{{ suffix }}<br/>
         <small>
@@ -67,19 +95,43 @@
                 relations, ontological relations, properties, and data, assembled at scale automatically from the
                 scientific literature and structured sources.
             </p>
-            <div class="row text-center stats">
-                {{ count_column(node_counter, "BioEntity", "Biological Entities", "dna") }}
-                {{ count_column(node_counter, "ClinicalTrial", "Clinical Trials", "clinic-medical") }}
-                {{ count_column(node_counter, "Publication", "Publications", "book") }}
-                {{ count_column(node_counter, "Evidence", "Evidences", "puzzle-piece") }}
-                {{ count_column(node_counter, "ResearchProject", "Research Projects", "flask") }}
-                {{ count_column(node_counter, "Patent", "Patents", "copyright") }}
+            {% set total_node_count, total_node_suffix = format_number(total_nodes) %}
+            {% set total_edge_count, total_edge_suffix = format_number(total_edges) %}
+            <div class="row text-center stats stats-summary"
+                 data-toggle="collapse"
+                 data-target="#graph-stats-details"
+                 aria-expanded="false"
+                 aria-controls="graph-stats-details"
+                 role="button"
+                 tabindex="0">
+                <div class="col">
+                    <i class="fa fa-database"></i>
+                    <h2><span class="count-total-nodes" data-to="{{ total_node_count }}" data-time="1000"></span>{{ total_node_suffix }}</h2>
+                    <p class="count-text">Nodes</p>
+                </div>
+                <div class="col">
+                    <i class="fa fa-project-diagram"></i>
+                    <h2><span class="count-total-edges" data-to="{{ total_edge_count }}" data-time="1000"></span>{{ total_edge_suffix }}</h2>
+                    <p class="count-text">Edges</p>
+                </div>
+                <div class="col-12">
+                    <small class="text-muted stats-toggle-hint">
+                        Detailed node and edge breakdown <i class="fa fa-chevron-down stats-chevron"></i>
+                    </small>
+                </div>
             </div>
-            <div class="row text-center stats" style="padding-left: 3em; padding-right: 3em;">
-                {% for spec in edge_specs_sorted %}
-                    {% set key = spec["key"] if "key" in spec else spec["rel_type"] %}
-                    {{ count_column_small(edge_counter, key, spec["label"]) }}
-                {% endfor %}
+            <div class="collapse" id="graph-stats-details">
+                <div class="row text-center stats">
+                    {% for spec in node_count_info %}
+                        {{ count_column(node_counter, spec["node_label"], spec["label"], spec["icon"], spec.get("info", "")) }}
+                    {% endfor %}
+                </div>
+                <div class="row text-center stats" style="padding-left: 3em; padding-right: 3em;">
+                    {% for spec in edge_specs_sorted %}
+                        {% set key = spec["key"] if "key" in spec else spec["rel_type"] %}
+                        {{ count_column_small(edge_counter, key, spec["label"], spec.get("info", "")) }}
+                    {% endfor %}
+                </div>
             </div>
         </div>
     </div>
@@ -386,37 +438,58 @@
     <script>
         (function ($) {
             $.fn.counter = function () {
-                const $this = $(this),
-                    numberFrom = 0,
-                    numberTo = parseInt($this.attr('data-to')),
-                    delta = numberTo - numberFrom,
-                    deltaPositive = delta > 0,
-                    time = parseInt($this.attr('data-time')),
-                    changeTime = 10;
+                return this.each(function () {
+                    const $this = $(this);
+                    if ($this.attr('data-counter-started')) {
+                        return;
+                    }
+                    $this.attr('data-counter-started', 'true');
 
-                let currentNumber = 0,
-                    value = delta * changeTime / time;
-                let interval1;
-                const changeNumber = () => {
-                    currentNumber += value;
-                    //checks if currentNumber reached numberTo
-                    (deltaPositive && currentNumber >= numberTo) || (!deltaPositive && currentNumber <= numberTo) ? currentNumber = numberTo : currentNumber;
-                    this.text(parseInt(currentNumber));
-                    currentNumber === numberTo ? clearInterval(interval1) : currentNumber;
-                }
+                    const numberFrom = 0,
+                        numberTo = parseInt($this.attr('data-to')),
+                        delta = numberTo - numberFrom,
+                        deltaPositive = delta > 0,
+                        time = parseInt($this.attr('data-time')),
+                        changeTime = 10;
 
-                interval1 = setInterval(changeNumber, changeTime);
+                    let currentNumber = 0,
+                        value = delta * changeTime / time;
+                    let interval1;
+                    const changeNumber = () => {
+                        currentNumber += value;
+                        //checks if currentNumber reached numberTo
+                        (deltaPositive && currentNumber >= numberTo) || (!deltaPositive && currentNumber <= numberTo) ? currentNumber = numberTo : currentNumber;
+                        $this.text(parseInt(currentNumber));
+                        currentNumber === numberTo ? clearInterval(interval1) : currentNumber;
+                    }
+
+                    interval1 = setInterval(changeNumber, changeTime);
+                });
             }
         }(jQuery));
 
         $(document).ready(function () {
-            {% for key in node_counter %}
-                $('.count-{{ key }}').counter();
-            {% endfor %}
-            {% for spec in edge_specs_sorted %}
-                {% set key = spec["key"] if "key" in spec else spec["rel_type"] %}
-                $('.count-{{ key }}').counter();
-            {% endfor %}
+            $('.count-total-nodes, .count-total-edges').counter();
+
+            $('#graph-stats-details [data-toggle="tooltip"]').tooltip({container: 'body'});
+
+            const $statsSummary = $('.stats-summary');
+            const $statsDetails = $('#graph-stats-details');
+            $statsDetails.on('shown.bs.collapse', function () {
+                $statsSummary.attr('aria-expanded', 'true');
+                $('.stats-toggle-hint').html('Hide breakdown <i class="fa fa-chevron-down stats-chevron"></i>');
+                $('#graph-stats-details [data-to]:not([data-counter-started])').counter();
+            });
+            $statsDetails.on('hidden.bs.collapse', function () {
+                $statsSummary.attr('aria-expanded', 'false');
+                $('.stats-toggle-hint').html('Show breakdown <i class="fa fa-chevron-down stats-chevron"></i>');
+            });
+            $statsSummary.on('keydown', function (e) {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    $statsDetails.collapse('toggle');
+                }
+            });
         });
     </script>
 {% endblock %}

--- a/src/indra_cogex/apps/templates/home.html
+++ b/src/indra_cogex/apps/templates/home.html
@@ -124,6 +124,7 @@
          {% if info %}
          data-toggle="tooltip"
          data-placement="top"
+         data-html="true"
          title="{{ info }}"
          {% endif %}>
         {% if icon %}

--- a/src/indra_cogex/client/queries.py
+++ b/src/indra_cogex/client/queries.py
@@ -116,6 +116,8 @@ __all__ = [
     "get_network",
     # Summary functions
     "get_node_counter",
+    "count_edges",
+    "get_curated_edge_counter",
     "get_edge_counter",
     "get_schema_graph",
 ]
@@ -1698,6 +1700,81 @@ def get_prefix_counter(*, client: Neo4jClient) -> Counter:
         """MATCH (n) WITH split(n.id, ":")[0] as prefix RETURN prefix, count(prefix)"""
     )
     return Counter(dict(client.query_tx(cypher)))
+
+
+@autoclient(cache=True, maxsize=128)  # Expecting rel types to stay at < 128
+def count_edges(
+    rel_type: str,
+    *,
+    source_label: Optional[str] = None,
+    target_label: Optional[str] = None,
+    client: Neo4jClient,
+) -> int:
+    """Count edges of a given type, optionally filtered by endpoint labels
+
+    Parameters
+    ----------
+    rel_type :
+        The relationship type to count.
+    source_label :
+        The label of the source node. If None, counts all edges regardless of
+        source node label.
+    target_label :
+        The label of the target node. If None, counts all edges regardless of
+        target node label.
+    client :
+        The Neo4j client.
+
+    Returns
+    -------
+    :
+        The count of edges of the given type, optionally filtered by endpoint
+        labels.
+    """
+    source = f"(s:{source_label})" if source_label else "()"
+    target = f"(t:{target_label})" if target_label else "()"
+    return client.query_tx(
+        f"MATCH {source}-[r:{rel_type}]->{target} RETURN count(*)",
+        squeeze=True,
+    )[0]
+
+
+@autoclient()
+def get_curated_edge_counter(
+    edge_count_info: list[dict[str, str]], *, client: Neo4jClient
+) -> Counter:
+    """Get edge counts for a curated list of relationship specs
+
+    Parameters
+    ----------
+    edge_count_info :
+        A list of dictionaries, each containing the following keys:
+        - "rel_type": The relationship type to count.
+        - "label": The human-readable label for the relationship type. Defaults
+          to "rel_type".
+        - "info": The human-readable description of the relationship type.
+        - "key": The key to use in the returned Counter. Defaults to "rel_type".
+          This field is only used to distinguish between edges of the same
+          relationship type that are used in more than one context.
+        - "source_label": The label of the source node.
+        - "target_label": The label of the target node.
+
+    Returns
+    -------
+    :
+        A Counter containing the counts for each provided relationship type.
+    """
+    return Counter(
+        {
+            info_dict.get("key", info_dict["rel_type"]): count_edges(
+                info_dict["rel_type"],
+                source_label=info_dict.get("source_label"),
+                target_label=info_dict.get("target_label"),
+                client=client,
+            )
+            for info_dict in edge_count_info
+        }
+    )
 
 
 @autoclient(cache=True)


### PR DESCRIPTION
This PR updates the node and edge summaries on the landing page for discovery.indra.bio.

- Node and edge information is moved to dedicated JSON files, living in `indra_cogex/apps/static/`
- `indra_cogex/apps/templates/home.html` is updated:
  - There are now only two counters for total nodes and edges visible when page is loaded
  - A collapsible area holds detailed node and edge counters
  - Counter items are now slightly shrunk and placed in a grid with tighter margins to take up less space
  - Each item has a tooltip that adds extra details
  - Some reorganization:
    - No hard coding of node labels (because it's moved to the JSON)
    - Update JS to trigger the counter effect on expand